### PR TITLE
Allow non-admin users to edit via config option

### DIFF
--- a/packages/climate-schedule-card/src/card.ts
+++ b/packages/climate-schedule-card/src/card.ts
@@ -79,7 +79,11 @@ export class HomematicScheduleCard extends LitElement {
   @state() private _tempStep: number = 0.5;
 
   private get _isEditable(): boolean {
-    return (this._config?.editable ?? true) && this.hass?.user?.is_admin !== false;
+    const editable = this._config?.editable ?? true;
+    const allowNonAdmin = this._config?.allow_non_admin_edit ?? false;
+    const isAdmin = this.hass?.user?.is_admin !== false;
+
+    return editable && (isAdmin || allowNonAdmin);
   }
 
   public setConfig(config: HomematicScheduleCardConfig): void {
@@ -115,6 +119,7 @@ export class HomematicScheduleCard extends LitElement {
     this._config = {
       show_profile_selector: true,
       editable: true,
+      allow_non_admin_edit: true,
       show_temperature: true,
       temperature_unit: "\u00B0C",
       hour_format: "24",

--- a/packages/climate-schedule-card/src/editor.ts
+++ b/packages/climate-schedule-card/src/editor.ts
@@ -56,6 +56,11 @@ export class HomematicScheduleCardEditor extends LitElement {
       default: true,
     },
     {
+      name: "allow_non_admin_edit",
+      selector: { boolean: {} },
+      default: false,
+    },
+    {
       name: "show_temperature",
       selector: { boolean: {} },
       default: true,
@@ -217,6 +222,7 @@ export class HomematicScheduleCardEditor extends LitElement {
       name: "Card Name (optional)",
       show_profile_selector: "Show profile selector",
       editable: "Allow editing",
+      allow_non_admin_edit: "Allow non-admin users to edit",
       show_temperature: "Show temperature values",
       show_gradient: "Show color gradient",
       hour_format: "Time format",

--- a/packages/climate-schedule-card/src/types.ts
+++ b/packages/climate-schedule-card/src/types.ts
@@ -38,6 +38,7 @@ export interface HomematicScheduleCardConfig {
   profile?: string;
   show_profile_selector?: boolean;
   editable?: boolean;
+  allow_non_admin_edit?: boolean;
   show_temperature?: boolean;
   temperature_unit?: string;
   hour_format?: "12" | "24";


### PR DESCRIPTION
### Make editing configurable for non-admin users

This PR introduces a new optional configuration flag:

`allow_non_admin_edit`

#### Behavior

* By default, editing remains restricted to admin users (no breaking change)
* When enabled, non-admin users are also allowed to edit

#### Motivation

In some setups (e.g. shared households), it is useful to allow non-admin users to make edits without granting full admin privileges.

This keeps the current default behavior while adding flexibility.

#### Changes

* Added new config option to schema and types
* Updated edit permission logic
* Added label for UI configuration
