### PR TITLE
Config Panel — Fix Time Selector Base Unit Mapping (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Config Panel — Fix Time Selector Base Unit Mapping
+
+Fixes [#63](https://github.com/SukramJ/homematicip-local-frontend/issues/63): in a direct device link (e.g. HmIP-PCBS2), a custom on-time configured on the CCU as `3 × 100 ms = 300 ms` was shown as "Not active" with no factor field. The link time selector hard-coded a `TIME_UNITS` table that did not match the CCU's `DURATION_BASE` encoding — it invented an "inactive" unit at `base 0`, shifted every real unit up by one, and dropped the `5 min` unit entirely. As a result `base 0` (= 100 ms) was rendered as "Not active", and the factor input was hidden for `base 0`.
+
+- **Config panel — time selector** (`components/form-time-selector.ts`):
+  - Aligned `TIME_UNITS` with the authoritative CCU encoding mirrored by `aiohomematic-config`'s `_TIME_BASE_UNITS`: `base 0`=100 ms, `1`=1 s, `2`=5 s, `3`=10 s, `4`=1 min, `5`=5 min (previously missing), `6`=10 min, `7`=1 h. Removed the fake "inactive" unit — inactive is expressed as `factor=0` via the presets.
+  - The custom-mode factor input is now always shown (removed the `baseValue > 0` guard), since `base 0` is a real unit.
+- **Translations**: added `time_selector.unit_5minutes` (`5-minute steps` / `5-Minuten-Schritte`) to `en.json` / `de.json`.
+
+This also corrects previously wrong duration hints across the board (e.g. `1 min` was shown as `10 s`, `5 min` as `1 min`).
+
 ### Dependency Updates — TypeScript 6, lint-staged 17
 
 Bumped the toolchain to current latest. Patch updates for `eslint` (10.4.0), `jest` (30.4.2), `jest-environment-jsdom` (30.4.1), `lit` (3.3.3), `prettier` (3.8.3), `rollup` (4.60.4), `@rollup/plugin-commonjs` (29.0.2), `ts-jest` (29.4.11), `typescript-eslint` (8.60.0). Major bumps for `lint-staged` (16 → 17) and `typescript` (5.9.3 → 6.0.3). Two moderate transitive vulnerabilities (`brace-expansion`, `ws`) resolved via the patches → 0 vulnerabilities.

--- a/packages/config-panel/src/components/form-time-selector.ts
+++ b/packages/config-panel/src/components/form-time-selector.ts
@@ -11,13 +11,16 @@ interface TimeUnit {
   labelKey: string;
 }
 
+// Base-value → seconds-per-unit mapping. Must stay in sync with the CCU
+// firmware encoding (mirrored by aiohomematic-config's `_TIME_BASE_UNITS`).
+// "Inactive" is not a base unit — it is expressed as factor=0 (a preset).
 const TIME_UNITS: TimeUnit[] = [
-  { base: 0, multiplierSeconds: 0, labelKey: "time_selector.unit_inactive" },
-  { base: 1, multiplierSeconds: 0.1, labelKey: "time_selector.unit_100ms" },
-  { base: 2, multiplierSeconds: 1, labelKey: "time_selector.unit_seconds" },
-  { base: 3, multiplierSeconds: 5, labelKey: "time_selector.unit_5seconds" },
-  { base: 4, multiplierSeconds: 10, labelKey: "time_selector.unit_10seconds" },
-  { base: 5, multiplierSeconds: 60, labelKey: "time_selector.unit_minutes" },
+  { base: 0, multiplierSeconds: 0.1, labelKey: "time_selector.unit_100ms" },
+  { base: 1, multiplierSeconds: 1, labelKey: "time_selector.unit_seconds" },
+  { base: 2, multiplierSeconds: 5, labelKey: "time_selector.unit_5seconds" },
+  { base: 3, multiplierSeconds: 10, labelKey: "time_selector.unit_10seconds" },
+  { base: 4, multiplierSeconds: 60, labelKey: "time_selector.unit_minutes" },
+  { base: 5, multiplierSeconds: 300, labelKey: "time_selector.unit_5minutes" },
   { base: 6, multiplierSeconds: 600, labelKey: "time_selector.unit_10minutes" },
   { base: 7, multiplierSeconds: 3600, labelKey: "time_selector.unit_hours" },
 ];
@@ -188,20 +191,16 @@ export class HmTimeSelector extends LitElement {
                     @closed=${(e: Event) => e.stopPropagation()}
                   ></ha-select>
                 </div>
-                ${this.baseValue > 0
-                  ? html`
-                      <div class="custom-field">
-                        <label class="custom-label">${this._l("time_selector.value")}:</label>
-                        <input
-                          type="number"
-                          min="0"
-                          max="31"
-                          .value=${String(this.factorValue)}
-                          @change=${this._handleValueChange}
-                        />
-                      </div>
-                    `
-                  : nothing}
+                <div class="custom-field">
+                  <label class="custom-label">${this._l("time_selector.value")}:</label>
+                  <input
+                    type="number"
+                    min="0"
+                    max="31"
+                    .value=${String(this.factorValue)}
+                    @change=${this._handleValueChange}
+                  />
+                </div>
                 ${durationText ? html`<div class="duration-hint">${durationText}</div>` : nothing}
               </div>
             `

--- a/packages/config-panel/translations/de.json
+++ b/packages/config-panel/translations/de.json
@@ -84,6 +84,7 @@
     "unit_5seconds": "5-Sekunden-Schritte",
     "unit_10seconds": "10-Sekunden-Schritte",
     "unit_minutes": "Minuten",
+    "unit_5minutes": "5-Minuten-Schritte",
     "unit_10minutes": "10-Minuten-Schritte",
     "unit_hours": "Stunden",
     "permanent": "Dauerhaft"

--- a/packages/config-panel/translations/en.json
+++ b/packages/config-panel/translations/en.json
@@ -84,6 +84,7 @@
     "unit_5seconds": "5-second steps",
     "unit_10seconds": "10-second steps",
     "unit_minutes": "Minutes",
+    "unit_5minutes": "5-minute steps",
     "unit_10minutes": "10-minute steps",
     "unit_hours": "Hours",
     "permanent": "Permanent"


### PR DESCRIPTION
## Summary

Fixes #63. In a direct device link (e.g. HmIP-PCBS2), a custom on-time configured on the CCU as `3 × 100 ms = 300 ms` was displayed as **"Not active"** with no factor field.

## Root cause

The link time selector (`form-time-selector.ts`) hard-coded a `TIME_UNITS` table that did **not** match the CCU's `DURATION_BASE` encoding (mirrored by `aiohomematic-config`'s `_TIME_BASE_UNITS`):

| base | CCU (correct) | Frontend (was) |
|------|---------------|----------------|
| 0 | **100 ms** | `inactive` ❌ |
| 1 | 1 s | 100 ms ❌ |
| 2 | 5 s | 1 s ❌ |
| 3 | 10 s | 5 s ❌ |
| 4 | 1 min | 10 s ❌ |
| 5 | **5 min** | 1 min ❌ |
| 6 | 10 min | 10 min ✅ |
| 7 | 1 h | 1 h ✅ |

It invented an "inactive" unit at `base 0`, shifted every real unit up by one, and dropped the `5 min` unit. So `base 0` (= 100 ms) rendered as "Not active", and the factor input was hidden via the `baseValue > 0` guard.

## Changes

- **`components/form-time-selector.ts`**: aligned `TIME_UNITS` with the authoritative CCU encoding; removed the fake "inactive" unit (inactive = `factor 0` via presets); always show the custom-mode factor input.
- **`translations/en.json` / `de.json`**: added `time_selector.unit_5minutes` (`5-minute steps` / `5-Minuten-Schritte`).
- **`CHANGELOG.md`**: added an entry under Unreleased.

This also corrects previously wrong duration hints in general (e.g. `1 min` was shown as `10 s`, `5 min` as `1 min`).

## Testing

- `npm run validate` — lint, type-check, 213 tests, build all pass.
- Deployed to the integration frontend; result is verified by the reporter.

> Note: the config panel has no Jest infrastructure (tests live in `schedule-core` only), so this fix is validated via build + manual verification rather than a regression test.