### PR TITLE
chore(ci): harden CI supply chain and refresh branch references

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# yamllint disable-line rule:truthy
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "SukramJ"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "SukramJ"
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore"
+    groups:
+      npm:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main, devel]
+    branches: [main]
   pull_request:
-    branches: [main, devel]
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   validate:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'SukramJ'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v6.0.0
+      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7  # v6.0.0
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: "0.1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       run: npm test
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
       with:
         name: "${{ steps.package.outputs.DISPLAY_NAME }} v${{ steps.package.outputs.VERSION }}"
         body: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,7 +472,7 @@ Husky + lint-staged run automatically on commit:
 
 ### CI Pipeline (GitHub Actions)
 
-Runs on push/PR to `main`/`devel`:
+Runs on push/PR to `main`:
 
 - Node.js matrix: 20.x, 22.x
 - Steps: install, lint, type-check, test, build
@@ -691,7 +691,7 @@ git push origin main --tags
 
 | Workflow | File                            | Trigger                           | Steps                                   |
 | -------- | ------------------------------- | --------------------------------- | --------------------------------------- |
-| CI       | `.github/workflows/ci.yml`      | Push/PR to `main`/`devel`         | lint → type-check → test → build        |
+| CI       | `.github/workflows/ci.yml`      | Push/PR to `main`                 | lint → type-check → test → build        |
 | Release  | `.github/workflows/release.yml` | Tag `climate-v*` or `schedule-v*` | install → build → test → GitHub release |
 
 ### Standalone Repo Structure

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ git push origin climate-v0.10.1
 
 | Workflow      | Trigger                                                              | Purpose                                       |
 | ------------- | -------------------------------------------------------------------- | --------------------------------------------- |
-| `ci.yml`      | Push/PR to `main`/`devel`                                            | Lint, type-check, test, build                 |
+| `ci.yml`      | Push/PR to `main`                                                    | Lint, type-check, test, build                 |
 | `release.yml` | Tag `climate-v*`, `schedule-v*`, `config-panel-v*`, `status-card-v*` | Build and create GitHub release with artifact |
 
 ## Project Structure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -327,7 +327,7 @@ This allows both versions to coexist during the transition period.
 
 ### CI/CD Workflows
 
-**CI** (push/PR to `main`/`devel`):
+**CI** (push/PR to `main`):
 
 ```
 npm ci → lint → type-check → test → build


### PR DESCRIPTION
## Summary

Hardens the GitHub Actions supply chain and removes stale branch references.

### Changes

- **Pin third-party actions to full commit SHA** (with inline `# vX` comment):
  - `dessant/lock-threads@v6.0.0` -> `7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7`
  - `softprops/action-gh-release@v2` -> `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65`
  - `actions/*` and `github/codeql-action/*` intentionally left on tags.
- **Add least-privilege `permissions: contents: read`** to `ci.yml` (was missing).
- **Refresh stale branch references** (repo default branch is `main`):
  - `ci.yml` push/PR triggers reduced from `[main, devel]` to `[main]`.
  - Docs updated: `CLAUDE.md`, `README.md`, `docs/architecture.md`.
- **Add `.github/dependabot.yml`** with conservative config:
  - `github-actions` ecosystem (weekly, reviewer `SukramJ`, labels, `chore` commit prefix, grouped).
  - `npm` ecosystem at `/` (weekly, grouped) — root `package.json` + `package-lock.json` present.

### Notes

- Only git-branch references were changed; "master"/"devel" used as nouns or in unrelated contexts were left untouched.
- All changed YAML validated for syntax.