### PR TITLE
fix(config-panel): show the CCU dashboard for the openccu-loom backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -754,6 +754,9 @@ These rules govern how AI assistants must approach all code changes in this proj
 20. **Box-shadow tokens renamed** (HA 2026.5+) — `--ha-color-shadow-light` (and siblings) removed; use `--ha-box-shadow-s`, `--ha-box-shadow-m`, `--ha-box-shadow-l`. New surface tokens: `--ha-color-surface-default` / `-low` / `-lower` (each with `-inverted` variant).
 21. **`ha-radio` removed** (HA 2026.6+) — Use `ha-radio-group` with `ha-radio-option` children; no `ha-formfield` wrapper needed. Selection via `@value-changed` (string values). For purely decorative radio indicators inside custom click-handling containers, `<ha-icon icon="mdi:radiobox-marked|mdi:radiobox-blank">` is simpler. Also: `ha-top-app-bar` removed, `--mdc-drawer-width` → `--ha-sidebar-width`, `--mdc-top-app-bar-width` → `--ha-top-app-bar-width`. See [`ha-radio` removed](#ha-radio-removed-ha-20266).
 22. **Firefox custom element registry bug** — Firefox replaces the `customElements` object between ES module eval and later execution. All cards are bundled into a single `all-cards.ts` entry point with a save & re-register recovery mechanism. See [Firefox Custom Element Registry Bug](#firefox-custom-element-registry-bug). Never split cards back into separate bundles.
+23. **Size tokens are short names** (HA 2026.7+) — `ha-button` takes `xs|s|m|l|xl`, `ha-button-toggle-group` and `ha-slider` take `s|m`. The old `small|medium|large` values are gone. We currently set no `size` on any of them; if you add one, use the short names. `ha-circular-progress` is unaffected and keeps `size="small"`.
+24. **HA frontend internals cannot be imported** — Mixins, contexts and utils (`DirtyStateProviderMixin`, `PreventUnsavedMixin`, `isNavigationClick`, …) live in the HA frontend's TypeScript sources; the `home-assistant-frontend` npm package ships only built assets. Custom elements are usable by tag name, everything else must be ported. See [Unsaved-changes guard](#unsaved-changes-guard).
+25. **Feature-detect HA components newer than the minimum** (currently HA 2026.3) — An unknown custom element renders as an empty inline element, so a missing component means a silently blank view, not an error. Gate it with `customElements.get("<tag>")` and keep a fallback. See [`ha-list-virtualized`](#ha-list-virtualized-ha-20267).
 
 ## Firefox Custom Element Registry Bug
 
@@ -930,6 +933,52 @@ Replaces `mwc-progress-bar`. Fully themeable via `--ha-progress-bar-indicator-co
 - **`ha-drawer`** migrated to webawesome drawer (API mostly unchanged).
 - CSS variables renamed: `--mdc-drawer-width` → `--ha-sidebar-width`, `--mdc-top-app-bar-width` → `--ha-top-app-bar-width`.
 - New `@consumeLocalize` decorator for components needing only the `localize` function.
+
+### Size attributes (HA 2026.7+)
+
+Three components switched from descriptive to Web Awesome short size names. The old values are no longer recognized:
+
+| Component                | Old                    | New               |
+| ------------------------ | ---------------------- | ----------------- |
+| `ha-button`              | `small\|medium\|large` | `xs\|s\|m\|l\|xl` |
+| `ha-button-toggle-group` | `small\|medium\|large` | `s\|m`            |
+| `ha-slider`              | `small\|medium\|large` | `s\|m`            |
+
+We set no `size` on any of these today. `ha-circular-progress` is **not** part of this change and keeps `size="small"` (used in `form-parameter.ts`).
+
+### `ha-list-virtualized` (HA 2026.7+)
+
+Virtualized list that renders only the visible rows. Used by the config panel's device list for large installations.
+
+```typescript
+<ha-list-virtualized
+  .rows=${rows}              // { id: string; interactive?: boolean; disabled?: boolean; ... }[]
+  .rowRenderer=${this._rowRenderer}   // (row, index) => TemplateResult
+></ha-list-virtualized>
+```
+
+**Three constraints that shape how we use it** (`views/device-list.ts`):
+
+1. **Feature-detected.** It does not exist before 2026.7, and an unknown element renders as an empty inline element — the device list would be silently blank. `_canVirtualize` checks `customElements.get("ha-list-virtualized")` and falls back to the plain grouped list. Our minimum stays HA 2026.3.
+2. **Rows live in the virtualizer's shadow root**, so the list's own styles do not reach them. The row markup is therefore its own element (`<hm-device-row>`, `components/device-row.ts`) carrying its own styles, used by both render paths. Row events need `composed: true` to escape.
+3. **It needs a bounded height** and scrolls its own container, so page-level scrolling and `position: sticky` interface headers do not work in this mode. We only virtualize above `VIRTUALIZE_THRESHOLD` (100 devices), where the trade is worth it.
+
+### Unsaved-changes guard
+
+HA 2026.7 added `DirtyStateProviderMixin` and `PreventUnsavedMixin`, but they are TypeScript sources inside the HA frontend — the `home-assistant-frontend` npm package ships only built assets, so **they cannot be imported** by our bundles.
+
+`src/unsaved-guard.ts` therefore ports the behaviour as a Lit `ReactiveController`. While the host reports `isDirty()`, it registers a capture-phase `click` listener plus `beforeunload`. `isNavigationClick()` (ported from HA, originally polymer/pwa-helpers) calls `preventDefault()` on in-app navigation clicks, which is what makes HA's own router skip the click; on discard, the listeners are removed and the original click is replayed on its target.
+
+Used by `channel-config.ts` and `link-config.ts`:
+
+```typescript
+private _unsavedGuard = new UnsavedGuard(this, {
+  isDirty: () => this._isDirty,
+  promptDiscard: () => this._promptDiscard(),
+});
+```
+
+This covers the HA sidebar and browser reload/close. A view's own back button is not covered — it calls `_promptDiscard()` itself.
 
 ### Quick Command Reference
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,231 @@
+# Makefile — HomematicIP Local Frontend
+#
+# Convenience frontend for the npm scripts in package.json. The npm scripts stay
+# the single source of truth; this file only makes them easier to discover and
+# adds the dependency ordering (schedule-core → schedule-ui → cards/panel) that
+# `npm run build --workspaces` does not express.
+#
+# Run `make` or `make help` for the target list.
+
+SHELL := /bin/bash
+.DEFAULT_GOAL := help
+
+# tsc and rollup share dist/ and tsbuildinfo state between packages; running
+# them concurrently corrupts incremental builds.
+.NOTPARALLEL:
+
+NPM ?= npm
+
+# Version bump level for the version-* targets: patch | minor | major
+BUMP ?= patch
+
+# npm writes this file on every install; using it as a sentinel means a fresh
+# clone bootstraps itself and repeated builds skip the install.
+NODE_MODULES := node_modules/.package-lock.json
+
+$(NODE_MODULES): package.json package-lock.json
+	$(NPM) install
+	@touch $@
+
+##@ Setup
+
+.PHONY: install
+install: ## Install dependencies reproducibly from package-lock.json (CI-style)
+	$(NPM) ci
+
+.PHONY: install-dev
+install-dev: $(NODE_MODULES) ## Install dependencies, updating package-lock.json if needed
+
+.PHONY: hooks
+hooks: $(NODE_MODULES) ## (Re-)install the husky git hooks
+	$(NPM) run prepare
+
+##@ Quality
+
+.PHONY: lint
+lint: $(NODE_MODULES) ## Run ESLint
+	$(NPM) run lint
+
+.PHONY: lint-fix
+lint-fix: $(NODE_MODULES) ## Run ESLint with auto-fix
+	$(NPM) run lint:fix
+
+.PHONY: format
+format: $(NODE_MODULES) ## Format sources with Prettier
+	$(NPM) run format
+
+.PHONY: format-check
+format-check: $(NODE_MODULES) ## Check formatting without writing
+	$(NPM) run format:check
+
+.PHONY: type-check
+type-check: $(NODE_MODULES) ## TypeScript check across all packages
+	$(NPM) run type-check
+
+.PHONY: test
+test: $(NODE_MODULES) ## Run all tests
+	$(NPM) test
+
+.PHONY: test-watch
+test-watch: $(NODE_MODULES) ## Run schedule-core tests in watch mode
+	$(NPM) test -w packages/schedule-core -- --watch
+
+.PHONY: test-coverage
+test-coverage: $(NODE_MODULES) ## Run schedule-core tests with coverage report
+	npx jest --coverage -w packages/schedule-core
+
+.PHONY: validate
+validate: $(NODE_MODULES) ## Full pipeline: lint + type-check + test + build
+	$(NPM) run validate
+
+.PHONY: ci
+ci: install lint type-check test build ## What GitHub Actions runs (clean install first)
+
+##@ Build
+
+.PHONY: build
+build: $(NODE_MODULES) ## Build all packages
+	$(NPM) run build
+
+.PHONY: build-core
+build-core: $(NODE_MODULES) ## Build @hmip/schedule-core
+	$(NPM) run build:core
+
+.PHONY: build-ui
+build-ui: build-core ## Build @hmip/schedule-ui (needs schedule-core)
+	$(NPM) run build:ui
+
+.PHONY: build-panel-api
+build-panel-api: $(NODE_MODULES) ## Build @hmip/panel-api
+	$(NPM) run build -w packages/panel-api
+
+.PHONY: build-libs
+build-libs: build-ui build-panel-api ## Build all libraries (core, ui, panel-api)
+
+.PHONY: build-config-panel
+build-config-panel: build-libs ## Bundle the config panel
+	$(NPM) run build -w packages/config-panel
+
+.PHONY: build-status-card
+build-status-card: build-libs ## Bundle all cards (combined all-cards bundle)
+	$(NPM) run build -w packages/status-card
+
+.PHONY: build-climate-card
+build-climate-card: build-libs ## Bundle the climate schedule card (standalone HACS build)
+	$(NPM) run build -w packages/climate-schedule-card
+
+.PHONY: build-schedule-card
+build-schedule-card: build-libs ## Bundle the schedule card (standalone HACS build)
+	$(NPM) run build -w packages/schedule-card
+
+##@ Watch
+
+.PHONY: watch-config-panel
+watch-config-panel: build-libs ## Rebuild the config panel on change
+	$(NPM) run watch -w packages/config-panel
+
+.PHONY: watch-status-card
+watch-status-card: build-libs ## Rebuild the all-cards bundle on change
+	$(NPM) run watch -w packages/status-card
+
+.PHONY: watch-climate-card
+watch-climate-card: build-libs ## Rebuild the climate schedule card on change
+	$(NPM) run watch -w packages/climate-schedule-card
+
+.PHONY: watch-schedule-card
+watch-schedule-card: build-libs ## Rebuild the schedule card on change
+	$(NPM) run watch -w packages/schedule-card
+
+##@ Deploy (copies build artifacts into ../homematicip_local)
+
+.PHONY: deploy-config-panel
+deploy-config-panel: build-config-panel ## Deploy homematic-config.js to the integration
+	$(NPM) run deploy:config-panel
+
+.PHONY: deploy-status-card
+deploy-status-card: build-status-card ## Deploy homematicip-local-all-cards.js to the integration
+	$(NPM) run deploy:status-card
+
+.PHONY: deploy
+deploy: build ## Deploy config panel and all-cards bundle to the integration
+	$(NPM) run deploy:all
+
+##@ Release (validates, builds, deploys, tags — use the -dry targets first)
+
+.PHONY: release-config-panel-dry
+release-config-panel-dry: $(NODE_MODULES) ## Preview the config-panel release
+	$(NPM) run release:config-panel:dry
+
+.PHONY: release-config-panel
+release-config-panel: $(NODE_MODULES) ## Release the config panel
+	$(NPM) run release:config-panel
+
+.PHONY: release-status-card-dry
+release-status-card-dry: $(NODE_MODULES) ## Preview the status-card release
+	$(NPM) run release:status-card:dry
+
+.PHONY: release-status-card
+release-status-card: $(NODE_MODULES) ## Release the all-cards bundle
+	$(NPM) run release:status-card
+
+.PHONY: release-climate-dry
+release-climate-dry: $(NODE_MODULES) ## Preview the climate-schedule-card release
+	$(NPM) run release:climate:dry
+
+.PHONY: release-climate
+release-climate: $(NODE_MODULES) ## Release the climate schedule card
+	$(NPM) run release:climate
+
+.PHONY: release-schedule-dry
+release-schedule-dry: $(NODE_MODULES) ## Preview the schedule-card release
+	$(NPM) run release:schedule:dry
+
+.PHONY: release-schedule
+release-schedule: $(NODE_MODULES) ## Release the schedule card
+	$(NPM) run release:schedule
+
+##@ Versioning (BUMP=patch|minor|major, default: patch)
+
+.PHONY: version-config-panel
+version-config-panel: $(NODE_MODULES) ## Bump the config-panel version
+	$(NPM) run version:config-panel -- $(BUMP)
+
+.PHONY: version-status-card
+version-status-card: $(NODE_MODULES) ## Bump the status-card version
+	$(NPM) run version:status-card -- $(BUMP)
+
+.PHONY: version-climate
+version-climate: $(NODE_MODULES) ## Bump the climate-schedule-card version
+	$(NPM) run version:climate -- $(BUMP)
+
+.PHONY: version-schedule
+version-schedule: $(NODE_MODULES) ## Bump the schedule-card version
+	$(NPM) run version:schedule -- $(BUMP)
+
+.PHONY: versions
+versions: ## Show the current version of every package
+	@for pkg in packages/*/package.json; do \
+		node -p "const p=require('./$$pkg'); p.name.padEnd(32) + p.version"; \
+	done
+
+##@ Cleanup
+
+.PHONY: clean
+clean: ## Remove all dist/ directories and tsbuildinfo files
+	$(NPM) run clean
+
+.PHONY: distclean
+distclean: clean ## Also remove node_modules
+	rm -rf node_modules packages/*/node_modules
+
+##@ Help
+
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN { \
+			FS = ":.*##"; \
+			printf "\nHomematicIP Local Frontend\n\nUsage:\n  make \033[36m<target>\033[0m\n" \
+		} \
+		/^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-26s\033[0m %s\n", $$1, $$2 } \
+		/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	@printf "\nExample: make version-status-card BUMP=minor\n\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5354,9 +5354,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/config-panel/src/components/device-row.ts
+++ b/packages/config-panel/src/components/device-row.ts
@@ -1,0 +1,266 @@
+import { LitElement, html, css, nothing } from "lit";
+import { property } from "lit/decorators.js";
+import { safeCustomElement } from "../safe-element";
+import { getDeviceIconUrl } from "../api";
+import { localize } from "../localize";
+import type { HomeAssistant, DeviceInfo, MaintenanceData } from "../types";
+
+/**
+ * A single device row in the device list.
+ *
+ * This is its own element rather than a template in `hm-device-list` because the
+ * virtualized list renders rows inside `ha-list-virtualized`'s shadow root, where
+ * the list's styles do not reach. Carrying its own styles lets the row render
+ * identically in both the virtualized and the plain list.
+ *
+ * @fires device-selected - `detail: { device: address, interfaceId }`, composed
+ * so it also escapes the virtualizer's shadow root.
+ */
+@safeCustomElement("hm-device-row")
+export class HmDeviceRow extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+  @property() public entryId = "";
+  @property({ attribute: false }) public device!: DeviceInfo;
+
+  updated(changedProps: Map<string, unknown>): void {
+    if (changedProps.has("hass") && this.hass) {
+      this.classList.toggle("dark-theme", this.hass.themes?.darkMode ?? false);
+    }
+  }
+
+  private _l(key: string, params?: Record<string, string | number>): string {
+    return localize(this.hass, key, params);
+  }
+
+  private _handleClick(): void {
+    this.dispatchEvent(
+      new CustomEvent("device-selected", {
+        detail: {
+          device: this.device.address,
+          interfaceId: this.device.interface_id,
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private _handleKeydown(e: KeyboardEvent): void {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      this._handleClick();
+    }
+  }
+
+  private _handleIconError(e: Event): void {
+    (e.target as HTMLImageElement).style.display = "none";
+  }
+
+  private _renderMaintenanceIcons(m: MaintenanceData) {
+    if (!m || Object.keys(m).length === 0) return nothing;
+    return html`
+      <div class="device-status">
+        ${
+          m.unreach === true
+            ? html`<ha-icon
+                class="status-badge unreachable"
+                .icon=${"mdi:close-circle"}
+                title="${this._l("device_list.unreachable")}"
+                aria-label="${this._l("device_list.unreachable")}"
+              ></ha-icon>`
+            : m.unreach === false
+              ? html`<ha-icon
+                  class="status-badge reachable"
+                  .icon=${"mdi:check-circle"}
+                  title="${this._l("device_list.reachable")}"
+                  aria-label="${this._l("device_list.reachable")}"
+                ></ha-icon>`
+              : nothing
+        }
+        ${
+          m.low_bat === true
+            ? html`<ha-icon
+                class="status-badge low-bat"
+                .icon=${"mdi:battery-alert"}
+                title="${this._l("device_list.low_battery")}"
+                aria-label="${this._l("device_list.low_battery")}"
+              ></ha-icon>`
+            : nothing
+        }
+        ${
+          m.config_pending === true
+            ? html`<ha-icon
+                class="status-badge config-pending"
+                .icon=${"mdi:clock-alert-outline"}
+                title="${this._l("device_list.config_pending")}"
+                aria-label="${this._l("device_list.config_pending")}"
+              ></ha-icon>`
+            : nothing
+        }
+      </div>
+    `;
+  }
+
+  render() {
+    const device = this.device;
+    if (!device) return nothing;
+
+    return html`
+      <div
+        class="device-card"
+        role="button"
+        tabindex="0"
+        @click=${this._handleClick}
+        @keydown=${this._handleKeydown}
+      >
+        ${
+          device.device_icon
+            ? html`<img
+                class="device-icon"
+                src=${getDeviceIconUrl(this.entryId, device.device_icon)}
+                alt=""
+                @error=${this._handleIconError}
+              />`
+            : nothing
+        }
+        <div class="device-main">
+          <div class="device-name">${device.name}</div>
+          <div class="device-model">${device.model}</div>
+        </div>
+        <div class="device-meta">
+          <span class="device-address">${device.address}</span>
+          <span class="device-channels">
+            ${device.channels.length} ${this._l("device_list.channels")}
+          </span>
+        </div>
+        ${this._renderMaintenanceIcons(device.maintenance)}
+        <ha-icon class="device-arrow" .icon=${"mdi:chevron-right"}></ha-icon>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .device-card {
+      display: flex;
+      align-items: center;
+      padding: 12px 8px;
+      cursor: pointer;
+      border-bottom: 1px solid var(--divider-color, #e0e0e0);
+      transition: background-color 0.1s;
+    }
+
+    .device-card:hover,
+    .device-card:focus-visible {
+      background-color: var(--secondary-background-color, #f5f5f5);
+    }
+
+    .device-card:focus-visible {
+      outline: 2px solid var(--primary-color, #03a9f4);
+      outline-offset: -2px;
+    }
+
+    .device-icon {
+      height: 32px;
+      width: 32px;
+      object-fit: contain;
+      flex-shrink: 0;
+      margin-right: 4px;
+    }
+
+    :host(.dark-theme) .device-icon {
+      filter: invert(1) hue-rotate(180deg);
+    }
+
+    .device-main {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .device-name {
+      font-size: 14px;
+      font-weight: 500;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .device-model {
+      font-size: 13px;
+      color: var(--secondary-text-color);
+      margin-top: 2px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .device-meta {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      margin-right: 12px;
+      font-size: 12px;
+      color: var(--secondary-text-color);
+    }
+
+    .device-status {
+      display: flex;
+      gap: 4px;
+      align-items: center;
+      margin-right: 8px;
+    }
+
+    .status-badge {
+      --ha-icon-display-size: 18px;
+      cursor: default;
+    }
+
+    .status-badge.unreachable {
+      color: var(--error-color, #db4437);
+    }
+
+    .status-badge.reachable {
+      color: var(--success-color, #4caf50);
+    }
+
+    .status-badge.low-bat {
+      color: var(--warning-color, #ff9800);
+    }
+
+    .status-badge.config-pending {
+      color: var(--warning-color, #ff9800);
+    }
+
+    .device-arrow {
+      --ha-icon-display-size: 18px;
+      color: var(--secondary-text-color);
+    }
+
+    @media (max-width: 600px) {
+      .device-card {
+        flex-wrap: wrap;
+      }
+
+      .device-meta {
+        flex-direction: row;
+        gap: 8px;
+        margin-right: 0;
+        width: 100%;
+        margin-top: 4px;
+      }
+
+      .device-arrow {
+        display: none;
+      }
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hm-device-row": HmDeviceRow;
+  }
+}

--- a/packages/config-panel/src/homematic-config.ts
+++ b/packages/config-panel/src/homematic-config.ts
@@ -17,6 +17,20 @@ import type { BreadcrumbItem } from "./components/breadcrumb";
 
 type PermissionScope = "schedule_edit" | "device_config" | "device_links" | "system_admin";
 
+/**
+ * Backends that serve the `homematicip_local/ccu/*` command surface, and thus
+ * the CCU dashboard (inbox, service/alarm messages, install mode, firmware,
+ * signal quality, backup, system information).
+ *
+ * `backend` is `central.model`. The direct-CCU (aiohomematic) backend reports
+ * `"CCU"`. The openccu-loom backend mediates the very same CCU through the
+ * daemon and implements the same commands, but reports its own backend-form
+ * identity `"openccu-loom"` — deliberately not `"CCU"`, because that value also
+ * drives entity dispatch and backend identity elsewhere. Gating on the literal
+ * `"CCU"` therefore hid the whole dashboard from loom-backed entries.
+ */
+const CCU_DASHBOARD_BACKENDS: readonly string[] = ["CCU", "openccu-loom"];
+
 type PanelTab = "devices" | "integration" | "ccu";
 
 type PanelView =
@@ -261,7 +275,7 @@ export class HomematicConfigPanel extends LitElement {
     ];
     if (this._hasPermission("system_admin")) {
       tabs.push({ id: "integration", label: this._l("tabs.integration") });
-      if (this._permissions?.backend === "CCU") {
+      if (CCU_DASHBOARD_BACKENDS.includes(this._permissions?.backend ?? "")) {
         tabs.push({ id: "ccu", label: this._l("tabs.ccu") });
       }
     }

--- a/packages/config-panel/src/unsaved-guard.ts
+++ b/packages/config-panel/src/unsaved-guard.ts
@@ -1,0 +1,123 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+/**
+ * Returns the in-app navigation target of a click, or undefined if the click is
+ * not an in-app navigation (modifier keys, external/download links, mailto, ...).
+ *
+ * Ported from Home Assistant's `isNavigationClick` (which took it from
+ * polymer/pwa-helpers, BSD-3). HA ships no consumable sources for third-party
+ * bundles, so the behaviour is mirrored rather than imported — most importantly
+ * the `preventDefault()`, which is what makes HA's own router skip the click.
+ */
+export function isNavigationClick(e: MouseEvent, preventDefault = true): string | undefined {
+  if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey) {
+    return undefined;
+  }
+
+  const anchor = e.composedPath().find((n) => (n as HTMLElement).tagName === "A") as
+    HTMLAnchorElement | undefined;
+  if (
+    !anchor ||
+    anchor.target ||
+    anchor.hasAttribute("download") ||
+    anchor.getAttribute("rel") === "external"
+  ) {
+    return undefined;
+  }
+
+  let href = anchor.href;
+  if (!href || href.includes("mailto:")) {
+    return undefined;
+  }
+
+  const origin = window.location.origin;
+  if (!href.startsWith(origin)) {
+    return undefined;
+  }
+  href = href.slice(origin.length);
+
+  if (href === "#") {
+    return undefined;
+  }
+
+  if (preventDefault) {
+    e.preventDefault();
+  }
+  return href;
+}
+
+interface UnsavedGuardOptions {
+  /** Whether the host currently holds unsaved changes. */
+  isDirty: () => boolean;
+  /** Ask the user to discard. Resolves true when navigation may proceed. */
+  promptDiscard: () => Promise<boolean>;
+}
+
+/**
+ * Guards against losing unsaved changes when the user leaves the view by means
+ * the view itself does not control: a click on HA's sidebar or any other in-app
+ * link, and a browser reload/close.
+ *
+ * The view's own back button is not covered — it handles the prompt itself.
+ *
+ * The click listener runs in the capture phase and cancels the click while the
+ * confirmation dialog is open. When the user discards, the listeners are removed
+ * and the original click is replayed on its target so the navigation goes through.
+ */
+export class UnsavedGuard implements ReactiveController {
+  private _host: ReactiveControllerHost;
+  private _options: UnsavedGuardOptions;
+  private _armed = false;
+
+  constructor(host: ReactiveControllerHost, options: UnsavedGuardOptions) {
+    this._host = host;
+    this._options = options;
+    host.addController(this);
+  }
+
+  hostUpdate(): void {
+    if (this._options.isDirty()) {
+      this._arm();
+    } else {
+      this._disarm();
+    }
+  }
+
+  hostDisconnected(): void {
+    this._disarm();
+  }
+
+  private _arm(): void {
+    if (this._armed) return;
+    window.addEventListener("click", this._handleClick, true);
+    window.addEventListener("beforeunload", this._handleUnload);
+    this._armed = true;
+  }
+
+  private _disarm(): void {
+    if (!this._armed) return;
+    window.removeEventListener("click", this._handleClick, true);
+    window.removeEventListener("beforeunload", this._handleUnload);
+    this._armed = false;
+  }
+
+  private _handleClick = async (e: MouseEvent): Promise<void> => {
+    const target = e.composedPath()[0];
+    if (!isNavigationClick(e)) {
+      return;
+    }
+
+    if (!(await this._options.promptDiscard())) {
+      return;
+    }
+
+    this._disarm();
+    if (target) {
+      target.dispatchEvent(new MouseEvent(e.type, e));
+    }
+  };
+
+  private _handleUnload = (e: BeforeUnloadEvent): void => {
+    e.preventDefault();
+  };
+}

--- a/packages/config-panel/src/views/channel-config.ts
+++ b/packages/config-panel/src/views/channel-config.ts
@@ -15,6 +15,7 @@ import {
 } from "../api";
 import { localize } from "../localize";
 import { showConfirmationDialog, showToast } from "../ha-helpers";
+import { UnsavedGuard } from "../unsaved-guard";
 import "../components/config-form";
 import { formatParameterValue } from "../components/form-parameter";
 import type { HomeAssistant, FormSchema } from "../types";
@@ -46,6 +47,12 @@ export class HmChannelConfig extends LitElement {
   // Session timeout tracking (5-minute server session)
   private static readonly _SESSION_WARNING_SECONDS = 270; // 4.5 minutes
   private _sessionTimerId?: ReturnType<typeof setTimeout>;
+
+  // Guards the HA sidebar / browser reload; the back button prompts on its own.
+  private _unsavedGuard = new UnsavedGuard(this, {
+    isDirty: () => this._isDirty,
+    promptDiscard: () => this._promptDiscard(),
+  });
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
@@ -380,16 +387,19 @@ export class HmChannelConfig extends LitElement {
     return undefined;
   }
 
+  private async _promptDiscard(): Promise<boolean> {
+    return showConfirmationDialog(this, {
+      title: this._l("channel_config.unsaved_title"),
+      text: this._l("channel_config.unsaved_warning"),
+      confirmText: this._l("channel_config.discard"),
+      dismissText: this._l("common.cancel"),
+      destructive: true,
+    });
+  }
+
   private async _handleBack(): Promise<void> {
-    if (this._isDirty) {
-      const confirmed = await showConfirmationDialog(this, {
-        title: this._l("channel_config.unsaved_title"),
-        text: this._l("channel_config.unsaved_warning"),
-        confirmText: this._l("channel_config.discard"),
-        dismissText: this._l("common.cancel"),
-        destructive: true,
-      });
-      if (!confirmed) return;
+    if (this._isDirty && !(await this._promptDiscard())) {
+      return;
     }
     // Clean up session
     if (this._sessionActive) {
@@ -433,14 +443,16 @@ export class HmChannelConfig extends LitElement {
       ></ha-icon-button>
 
       <div class="config-header">
-        ${this._schema?.device_icon
-          ? html`<img
-              class="device-icon"
-              src=${getDeviceIconUrl(this.entryId, this._schema.device_icon)}
-              alt=""
-              @error=${this._handleIconError}
-            />`
-          : nothing}
+        ${
+          this._schema?.device_icon
+            ? html`<img
+                class="device-icon"
+                src=${getDeviceIconUrl(this.entryId, this._schema.device_icon)}
+                alt=""
+                @error=${this._handleIconError}
+              />`
+            : nothing
+        }
         <div class="config-header-text">
           ${this.deviceName ? html`<h2>${this.deviceName}</h2>` : nothing}
           <div class="device-info">
@@ -465,62 +477,68 @@ export class HmChannelConfig extends LitElement {
       <div aria-live="polite">
         ${this._error ? html`<div class="error">${this._error}</div>` : nothing}
       </div>
-      ${this._schema
-        ? html`
-            <hm-config-form
-              .hass=${this.hass}
-              .schema=${this._schema}
-              .pendingChanges=${this._pendingChanges}
-              .validationErrors=${this._validationErrors}
-              .expertMode=${this._expertMode}
-              .entryId=${this.entryId}
-              .interfaceId=${this.interfaceId}
-              .channelAddress=${this.channelAddress}
-              @value-changed=${this._handleValueChanged}
-            ></hm-config-form>
-          `
-        : nothing}
-      ${this.editable
-        ? html`
-            <div class="action-bar-split action-bar-sticky">
-              <div class="action-bar-left">
-                <ha-icon-button
-                  @click=${this._handleUndo}
-                  .disabled=${!this._canUndo || this._saving}
-                  .label=${this._l("channel_config.undo")}
-                  .path=${"M12.5,8C9.85,8 7.45,9 5.6,10.6L2,7V16H11L7.38,12.38C8.77,11.22 10.54,10.5 12.5,10.5C16.04,10.5 19.05,12.81 20.1,16L22.47,15.22C21.08,11.03 17.15,8 12.5,8Z"}
-                ></ha-icon-button>
-                <ha-icon-button
-                  @click=${this._handleRedo}
-                  .disabled=${!this._canRedo || this._saving}
-                  .label=${this._l("channel_config.redo")}
-                  .path=${"M18.4,10.6C16.55,9 14.15,8 11.5,8C6.85,8 2.92,11.03 1.54,15.22L3.9,16C4.95,12.81 7.95,10.5 11.5,10.5C13.45,10.5 15.23,11.22 16.62,12.38L13,16H22V7L18.4,10.6Z"}
-                ></ha-icon-button>
+      ${
+        this._schema
+          ? html`
+              <hm-config-form
+                .hass=${this.hass}
+                .schema=${this._schema}
+                .pendingChanges=${this._pendingChanges}
+                .validationErrors=${this._validationErrors}
+                .expertMode=${this._expertMode}
+                .entryId=${this.entryId}
+                .interfaceId=${this.interfaceId}
+                .channelAddress=${this.channelAddress}
+                @value-changed=${this._handleValueChanged}
+              ></hm-config-form>
+            `
+          : nothing
+      }
+      ${
+        this.editable
+          ? html`
+              <div class="action-bar-split action-bar-sticky">
+                <div class="action-bar-left">
+                  <ha-icon-button
+                    @click=${this._handleUndo}
+                    .disabled=${!this._canUndo || this._saving}
+                    .label=${this._l("channel_config.undo")}
+                    .path=${"M12.5,8C9.85,8 7.45,9 5.6,10.6L2,7V16H11L7.38,12.38C8.77,11.22 10.54,10.5 12.5,10.5C16.04,10.5 19.05,12.81 20.1,16L22.47,15.22C21.08,11.03 17.15,8 12.5,8Z"}
+                  ></ha-icon-button>
+                  <ha-icon-button
+                    @click=${this._handleRedo}
+                    .disabled=${!this._canRedo || this._saving}
+                    .label=${this._l("channel_config.redo")}
+                    .path=${"M18.4,10.6C16.55,9 14.15,8 11.5,8C6.85,8 2.92,11.03 1.54,15.22L3.9,16C4.95,12.81 7.95,10.5 11.5,10.5C13.45,10.5 15.23,11.22 16.62,12.38L13,16H22V7L18.4,10.6Z"}
+                  ></ha-icon-button>
+                </div>
+                <div class="action-bar-right">
+                  <ha-button outlined @click=${this._handleResetDefaults} .disabled=${this._saving}>
+                    ${this._l("channel_config.reset_defaults")}
+                  </ha-button>
+                  <ha-button
+                    outlined
+                    @click=${this._handleDiscard}
+                    .disabled=${!this._isDirty || this._saving}
+                  >
+                    ${this._l("channel_config.discard")}
+                  </ha-button>
+                  <ha-button
+                    raised
+                    @click=${this._handleSave}
+                    .disabled=${!this._isDirty || this._saving}
+                  >
+                    ${
+                      this._saving
+                        ? this._l("channel_config.saving")
+                        : this._l("channel_config.save")
+                    }
+                  </ha-button>
+                </div>
               </div>
-              <div class="action-bar-right">
-                <ha-button outlined @click=${this._handleResetDefaults} .disabled=${this._saving}>
-                  ${this._l("channel_config.reset_defaults")}
-                </ha-button>
-                <ha-button
-                  outlined
-                  @click=${this._handleDiscard}
-                  .disabled=${!this._isDirty || this._saving}
-                >
-                  ${this._l("channel_config.discard")}
-                </ha-button>
-                <ha-button
-                  raised
-                  @click=${this._handleSave}
-                  .disabled=${!this._isDirty || this._saving}
-                >
-                  ${this._saving
-                    ? this._l("channel_config.saving")
-                    : this._l("channel_config.save")}
-                </ha-button>
-              </div>
-            </div>
-          `
-        : nothing}
+            `
+          : nothing
+      }
     `;
   }
 

--- a/packages/config-panel/src/views/device-list.ts
+++ b/packages/config-panel/src/views/device-list.ts
@@ -1,10 +1,22 @@
-import { LitElement, html, css, nothing } from "lit";
+import { LitElement, html, css, nothing, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 import { safeCustomElement } from "../safe-element";
 import { sharedStyles } from "../styles";
-import { listDevices, getDeviceIconUrl } from "../api";
+import { listDevices } from "../api";
 import { localize } from "../localize";
-import type { HomeAssistant, DeviceInfo, MaintenanceData } from "../types";
+import "../components/device-row";
+import type { HomeAssistant, DeviceInfo } from "../types";
+
+/**
+ * Below this many devices the plain (non-virtualized) list is used: virtualizing
+ * needs a fixed-height scroll container, which costs the sticky interface headers
+ * and the page-level scrolling, and buys nothing at small device counts.
+ */
+const VIRTUALIZE_THRESHOLD = 100;
+
+type DeviceListRow =
+  | { id: string; type: "header"; label: string; interactive: false }
+  | { id: string; type: "device"; device: DeviceInfo; interactive: true };
 
 @safeCustomElement("hm-device-list")
 export class HmDeviceList extends LitElement {
@@ -22,14 +34,6 @@ export class HmDeviceList extends LitElement {
     if (changedProps.has("entryId") && this.entryId) {
       this._fetchDevices();
     }
-    if (changedProps.has("hass") && this.hass) {
-      this._updateDarkMode();
-    }
-  }
-
-  private _updateDarkMode(): void {
-    const isDark = this.hass?.themes?.darkMode ?? false;
-    this.classList.toggle("dark-theme", isDark);
   }
 
   private async _fetchDevices(): Promise<void> {
@@ -83,60 +87,38 @@ export class HmDeviceList extends LitElement {
     return groups;
   }
 
-  private _handleDeviceClick(device: DeviceInfo): void {
-    this.dispatchEvent(
-      new CustomEvent("device-selected", {
-        detail: {
-          device: device.address,
-          interfaceId: device.interface_id,
-        },
-        bubbles: true,
-        composed: true,
-      }),
+  /** Groups and devices flattened into one row list for the virtualizer. */
+  private get _rows(): DeviceListRow[] {
+    const rows: DeviceListRow[] = [];
+    for (const [interfaceId, devices] of this._groupedDevices) {
+      rows.push({
+        id: `header:${interfaceId}`,
+        type: "header",
+        label: interfaceId,
+        interactive: false,
+      });
+      for (const device of devices) {
+        rows.push({
+          id: `device:${device.interface_id}:${device.address}`,
+          type: "device",
+          device,
+          interactive: true,
+        });
+      }
+    }
+    return rows;
+  }
+
+  /**
+   * `ha-list-virtualized` only exists from HA 2026.7 on. Falling back to the plain
+   * list keeps the panel working on older versions instead of rendering an unknown
+   * element (which would leave the list silently empty).
+   */
+  private get _canVirtualize(): boolean {
+    return (
+      customElements.get("ha-list-virtualized") !== undefined &&
+      this._filteredDevices.length > VIRTUALIZE_THRESHOLD
     );
-  }
-
-  private _handleIconError(e: Event): void {
-    (e.target as HTMLImageElement).style.display = "none";
-  }
-
-  private _renderMaintenanceIcons(m: MaintenanceData) {
-    if (!m || Object.keys(m).length === 0) return nothing;
-    return html`
-      <div class="device-status">
-        ${m.unreach === true
-          ? html`<ha-icon
-              class="status-badge unreachable"
-              .icon=${"mdi:close-circle"}
-              title="${this._l("device_list.unreachable")}"
-              aria-label="${this._l("device_list.unreachable")}"
-            ></ha-icon>`
-          : m.unreach === false
-            ? html`<ha-icon
-                class="status-badge reachable"
-                .icon=${"mdi:check-circle"}
-                title="${this._l("device_list.reachable")}"
-                aria-label="${this._l("device_list.reachable")}"
-              ></ha-icon>`
-            : nothing}
-        ${m.low_bat === true
-          ? html`<ha-icon
-              class="status-badge low-bat"
-              .icon=${"mdi:battery-alert"}
-              title="${this._l("device_list.low_battery")}"
-              aria-label="${this._l("device_list.low_battery")}"
-            ></ha-icon>`
-          : nothing}
-        ${m.config_pending === true
-          ? html`<ha-icon
-              class="status-badge config-pending"
-              .icon=${"mdi:clock-alert-outline"}
-              title="${this._l("device_list.config_pending")}"
-              aria-label="${this._l("device_list.config_pending")}"
-            ></ha-icon>`
-          : nothing}
-      </div>
-    `;
   }
 
   render() {
@@ -145,73 +127,106 @@ export class HmDeviceList extends LitElement {
         <h1>${this._l("device_list.title")}</h1>
       </div>
 
-      ${this.entryId
-        ? html`
-            <div class="search-bar">
-              <ha-input
-                .value=${this._searchQuery}
-                @input=${(e: InputEvent) => {
-                  this._searchQuery = (e.target as HTMLInputElement).value;
-                }}
-                .placeholder=${this._l("device_list.search_placeholder")}
-                aria-label=${this._l("device_list.search_placeholder")}
-              ></ha-input>
-            </div>
-            <div class="sort-bar">
-              <span class="sort-label">${this._l("device_list.sort_by")}:</span>
-              <button
-                class="sort-button ${this._sortColumn === "name" ? "active" : ""}"
-                @click=${() => this._setSortColumn("name")}
-              >
-                ${this._l("device_list.sort_name")}
-                ${this._sortColumn === "name"
-                  ? html`<ha-icon
-                      .icon=${this._sortAsc ? "mdi:arrow-up" : "mdi:arrow-down"}
-                    ></ha-icon>`
-                  : nothing}
-              </button>
-              <button
-                class="sort-button ${this._sortColumn === "address" ? "active" : ""}"
-                @click=${() => this._setSortColumn("address")}
-              >
-                ${this._l("device_list.sort_address")}
-                ${this._sortColumn === "address"
-                  ? html`<ha-icon
-                      .icon=${this._sortAsc ? "mdi:arrow-up" : "mdi:arrow-down"}
-                    ></ha-icon>`
-                  : nothing}
-              </button>
-              <button
-                class="sort-button ${this._sortColumn === "model" ? "active" : ""}"
-                @click=${() => this._setSortColumn("model")}
-              >
-                ${this._l("device_list.sort_model")}
-                ${this._sortColumn === "model"
-                  ? html`<ha-icon
-                      .icon=${this._sortAsc ? "mdi:arrow-up" : "mdi:arrow-down"}
-                    ></ha-icon>`
-                  : nothing}
-              </button>
-            </div>
-          `
-        : nothing}
-      ${this._loading
-        ? html`<div class="skeleton-container">
-            ${[1, 2, 3, 4, 5].map(() => html`<div class="skeleton-card"></div>`)}
-          </div>`
-        : this._error
-          ? html`<div class="error">
-              ${this._error}
-              <br />
-              <ha-button outlined @click=${this._fetchDevices}>
-                ${this._l("common.retry")}
-              </ha-button>
+      ${
+        this.entryId
+          ? html`
+              <div class="search-bar">
+                <ha-input
+                  .value=${this._searchQuery}
+                  @input=${(e: InputEvent) => {
+                    this._searchQuery = (e.target as HTMLInputElement).value;
+                  }}
+                  .placeholder=${this._l("device_list.search_placeholder")}
+                  aria-label=${this._l("device_list.search_placeholder")}
+                ></ha-input>
+              </div>
+              <div class="sort-bar">
+                <span class="sort-label">${this._l("device_list.sort_by")}:</span>
+                <button
+                  class="sort-button ${this._sortColumn === "name" ? "active" : ""}"
+                  @click=${() => this._setSortColumn("name")}
+                >
+                  ${this._l("device_list.sort_name")}
+                  ${
+                    this._sortColumn === "name"
+                      ? html`<ha-icon
+                          .icon=${this._sortAsc ? "mdi:arrow-up" : "mdi:arrow-down"}
+                        ></ha-icon>`
+                      : nothing
+                  }
+                </button>
+                <button
+                  class="sort-button ${this._sortColumn === "address" ? "active" : ""}"
+                  @click=${() => this._setSortColumn("address")}
+                >
+                  ${this._l("device_list.sort_address")}
+                  ${
+                    this._sortColumn === "address"
+                      ? html`<ha-icon
+                          .icon=${this._sortAsc ? "mdi:arrow-up" : "mdi:arrow-down"}
+                        ></ha-icon>`
+                      : nothing
+                  }
+                </button>
+                <button
+                  class="sort-button ${this._sortColumn === "model" ? "active" : ""}"
+                  @click=${() => this._setSortColumn("model")}
+                >
+                  ${this._l("device_list.sort_model")}
+                  ${
+                    this._sortColumn === "model"
+                      ? html`<ha-icon
+                          .icon=${this._sortAsc ? "mdi:arrow-up" : "mdi:arrow-down"}
+                        ></ha-icon>`
+                      : nothing
+                  }
+                </button>
+              </div>
+            `
+          : nothing
+      }
+      ${
+        this._loading
+          ? html`<div class="skeleton-container">
+              ${[1, 2, 3, 4, 5].map(() => html`<div class="skeleton-card"></div>`)}
             </div>`
-          : !this.entryId
-            ? html`<div class="empty-state">${this._l("device_list.no_entry_selected")}</div>`
-            : this._filteredDevices.length === 0
-              ? html`<div class="empty-state">${this._l("device_list.no_devices")}</div>`
-              : this._renderDeviceGroups()}
+          : this._error
+            ? html`<div class="error">
+                ${this._error}
+                <br />
+                <ha-button outlined @click=${this._fetchDevices}>
+                  ${this._l("common.retry")}
+                </ha-button>
+              </div>`
+            : !this.entryId
+              ? html`<div class="empty-state">${this._l("device_list.no_entry_selected")}</div>`
+              : this._filteredDevices.length === 0
+                ? html`<div class="empty-state">${this._l("device_list.no_devices")}</div>`
+                : this._canVirtualize
+                  ? this._renderVirtualizedDevices()
+                  : this._renderDeviceGroups()
+      }
+    `;
+  }
+
+  private _rowRenderer = (row: DeviceListRow): TemplateResult => {
+    if (row.type === "header") {
+      return html`<div class="interface-header virtualized">${row.label}</div>`;
+    }
+    return html`<hm-device-row
+      .hass=${this.hass}
+      .entryId=${this.entryId}
+      .device=${row.device}
+    ></hm-device-row>`;
+  };
+
+  private _renderVirtualizedDevices() {
+    return html`
+      <ha-list-virtualized
+        class="device-rows"
+        .rows=${this._rows}
+        .rowRenderer=${this._rowRenderer}
+      ></ha-list-virtualized>
     `;
   }
 
@@ -223,39 +238,11 @@ export class HmDeviceList extends LitElement {
             <div class="interface-header">${interfaceId}</div>
             ${devices.map(
               (device) => html`
-                <div
-                  class="device-card"
-                  role="button"
-                  tabindex="0"
-                  @click=${() => this._handleDeviceClick(device)}
-                  @keydown=${(e: KeyboardEvent) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      this._handleDeviceClick(device);
-                    }
-                  }}
-                >
-                  ${device.device_icon
-                    ? html`<img
-                        class="device-icon"
-                        src=${getDeviceIconUrl(this.entryId, device.device_icon)}
-                        alt=""
-                        @error=${this._handleIconError}
-                      />`
-                    : nothing}
-                  <div class="device-main">
-                    <div class="device-name">${device.name}</div>
-                    <div class="device-model">${device.model}</div>
-                  </div>
-                  <div class="device-meta">
-                    <span class="device-address">${device.address}</span>
-                    <span class="device-channels">
-                      ${device.channels.length} ${this._l("device_list.channels")}
-                    </span>
-                  </div>
-                  ${this._renderMaintenanceIcons(device.maintenance)}
-                  <ha-icon class="device-arrow" .icon=${"mdi:chevron-right"}></ha-icon>
-                </div>
+                <hm-device-row
+                  .hass=${this.hass}
+                  .entryId=${this.entryId}
+                  .device=${device}
+                ></hm-device-row>
               `,
             )}
           </div>
@@ -343,98 +330,18 @@ export class HmDeviceList extends LitElement {
         margin-bottom: 4px;
       }
 
-      .device-card {
-        display: flex;
-        align-items: center;
-        padding: 12px 8px;
-        cursor: pointer;
-        border-bottom: 1px solid var(--divider-color, #e0e0e0);
-        transition: background-color 0.1s;
+      /* The virtualizer scrolls its own container, so header rows cannot stick. */
+      .interface-header.virtualized {
+        position: static;
+        margin-top: 16px;
       }
 
-      .device-card:hover,
-      .device-card:focus-visible {
-        background-color: var(--secondary-background-color, #f5f5f5);
-      }
-
-      .device-card:focus-visible {
-        outline: 2px solid var(--primary-color, #03a9f4);
-        outline-offset: -2px;
-      }
-
-      .device-icon {
-        height: 32px;
-        width: 32px;
-        object-fit: contain;
-        flex-shrink: 0;
-        margin-right: 4px;
-      }
-
-      :host(.dark-theme) .device-icon {
-        filter: invert(1) hue-rotate(180deg);
-      }
-
-      .device-main {
-        flex: 1;
-      }
-
-      .device-name {
-        font-size: 14px;
-        font-weight: 500;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .device-model {
-        font-size: 13px;
-        color: var(--secondary-text-color);
-        margin-top: 2px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .device-meta {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-end;
-        margin-right: 12px;
-        font-size: 12px;
-        color: var(--secondary-text-color);
-      }
-
-      .device-status {
-        display: flex;
-        gap: 4px;
-        align-items: center;
-        margin-right: 8px;
-      }
-
-      .status-badge {
-        --ha-icon-display-size: 18px;
-        cursor: default;
-      }
-
-      .status-badge.unreachable {
-        color: var(--error-color, #db4437);
-      }
-
-      .status-badge.reachable {
-        color: var(--success-color, #4caf50);
-      }
-
-      .status-badge.low-bat {
-        color: var(--warning-color, #ff9800);
-      }
-
-      .status-badge.config-pending {
-        color: var(--warning-color, #ff9800);
-      }
-
-      .device-arrow {
-        --ha-icon-display-size: 18px;
-        color: var(--secondary-text-color);
+      /* The virtualizer needs a bounded height; the page itself no longer scrolls
+         the list in this mode. Sized to leave room for the header, search and sort bars. */
+      .device-rows {
+        display: block;
+        height: calc(100vh - 260px);
+        min-height: 320px;
       }
 
       .skeleton-container {
@@ -461,24 +368,6 @@ export class HmDeviceList extends LitElement {
         }
         100% {
           background-position: -200% 0;
-        }
-      }
-
-      @media (max-width: 600px) {
-        .device-card {
-          flex-wrap: wrap;
-        }
-
-        .device-meta {
-          flex-direction: row;
-          gap: 8px;
-          margin-right: 0;
-          width: 100%;
-          margin-top: 4px;
-        }
-
-        .device-arrow {
-          display: none;
         }
       }
     `,

--- a/packages/config-panel/src/views/link-config.ts
+++ b/packages/config-panel/src/views/link-config.ts
@@ -6,6 +6,7 @@ import { getLinkFormSchema, getLinkProfiles, putLinkParamset, testLinkProfile } 
 import type { FormParameter, ResolvedProfile } from "../api";
 import { localize } from "../localize";
 import { showConfirmationDialog, showToast } from "../ha-helpers";
+import { UnsavedGuard } from "../unsaved-guard";
 import "../components/config-form";
 import "../components/form-parameter";
 import "../components/form-time-selector";
@@ -40,6 +41,12 @@ export class HmLinkConfig extends LitElement {
   @state() private _selectedProfileId = 0;
   @state() private _testing = false;
   @state() private _activeKeypressTab: "short" | "long" = "short";
+
+  // Guards the HA sidebar / browser reload; the back button prompts on its own.
+  private _unsavedGuard = new UnsavedGuard(this, {
+    isDirty: () => this._isDirty,
+    promptDiscard: () => this._promptDiscard(),
+  });
 
   updated(changedProps: Map<string, unknown>): void {
     if (
@@ -316,16 +323,19 @@ export class HmLinkConfig extends LitElement {
     return undefined;
   }
 
+  private async _promptDiscard(): Promise<boolean> {
+    return showConfirmationDialog(this, {
+      title: this._l("link_config.unsaved_title"),
+      text: this._l("link_config.unsaved_warning"),
+      confirmText: this._l("link_config.discard"),
+      dismissText: this._l("common.cancel"),
+      destructive: true,
+    });
+  }
+
   private async _handleBack(): Promise<void> {
-    if (this._isDirty) {
-      const confirmed = await showConfirmationDialog(this, {
-        title: this._l("link_config.unsaved_title"),
-        text: this._l("link_config.unsaved_warning"),
-        confirmText: this._l("link_config.discard"),
-        dismissText: this._l("common.cancel"),
-        destructive: true,
-      });
-      if (!confirmed) return;
+    if (this._isDirty && !(await this._promptDiscard())) {
+      return;
     }
     this.dispatchEvent(new CustomEvent("back", { bubbles: true, composed: true }));
   }
@@ -357,17 +367,21 @@ export class HmLinkConfig extends LitElement {
             @selected=${this._handleProfileChange}
             @closed=${(e: Event) => e.stopPropagation()}
           ></ha-select>
-          ${this._selectedProfileId > 0
-            ? html`
-                <ha-button @click=${this._handleTestProfile} .disabled=${this._testing}>
-                  ${this._testing ? this._l("common.loading") : this._l("link_config.test_profile")}
-                </ha-button>
-              `
-            : nothing}
+          ${
+            this._selectedProfileId > 0
+              ? html`
+                  <ha-button @click=${this._handleTestProfile} .disabled=${this._testing}>
+                    ${this._testing ? this._l("common.loading") : this._l("link_config.test_profile")}
+                  </ha-button>
+                `
+              : nothing
+          }
         </div>
-        ${profileDescription
-          ? html`<p class="profile-description">${profileDescription}</p>`
-          : nothing}
+        ${
+          profileDescription
+            ? html`<p class="profile-description">${profileDescription}</p>`
+            : nothing
+        }
       </div>
     `;
   }
@@ -449,24 +463,26 @@ export class HmLinkConfig extends LitElement {
               ></ha-checkbox>
               ${this._l("link_config.last_value")}
             </label>
-            ${!isLastValue
-              ? html`
-                  <div class="slider-group">
-                    <input
-                      type="range"
-                      min="0"
-                      max="100"
-                      step="1"
-                      .value=${String(percent)}
-                      @input=${(e: Event) => {
-                        const pct = Number((e.target as HTMLInputElement).value);
-                        this._emitReceiverChange(param.id, pct / 100);
-                      }}
-                    />
-                    <span class="percent-display">${percent}%</span>
-                  </div>
-                `
-              : nothing}
+            ${
+              !isLastValue
+                ? html`
+                    <div class="slider-group">
+                      <input
+                        type="range"
+                        min="0"
+                        max="100"
+                        step="1"
+                        .value=${String(percent)}
+                        @input=${(e: Event) => {
+                          const pct = Number((e.target as HTMLInputElement).value);
+                          this._emitReceiverChange(param.id, pct / 100);
+                        }}
+                      />
+                      <span class="percent-display">${percent}%</span>
+                    </div>
+                  `
+                : nothing
+            }
           </div>
         </div>
       </div>
@@ -484,72 +500,76 @@ export class HmLinkConfig extends LitElement {
       return html`
         <div class="param-section">
           <h3>${this._l("link_config.receiver_params")}</h3>
-          ${showTabs
-            ? html`
-                <div class="keypress-tabs" role="tablist">
-                  <div
-                    class="tab ${this._activeKeypressTab === "short" ? "active" : ""}"
-                    role="tab"
-                    tabindex=${this._activeKeypressTab === "short" ? "0" : "-1"}
-                    aria-selected=${this._activeKeypressTab === "short"}
-                    @click=${() => {
-                      this._activeKeypressTab = "short";
-                    }}
-                    @keydown=${(e: KeyboardEvent) => {
-                      if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
-                        e.preventDefault();
-                        this._activeKeypressTab =
-                          this._activeKeypressTab === "short" ? "long" : "short";
-                        this.updateComplete.then(() => {
-                          const active = this.shadowRoot?.querySelector<HTMLElement>(
-                            '.tab[aria-selected="true"]',
-                          );
-                          active?.focus();
-                        });
-                      }
-                    }}
-                  >
-                    ${this._l("link_config.short_keypress")}
+          ${
+            showTabs
+              ? html`
+                  <div class="keypress-tabs" role="tablist">
+                    <div
+                      class="tab ${this._activeKeypressTab === "short" ? "active" : ""}"
+                      role="tab"
+                      tabindex=${this._activeKeypressTab === "short" ? "0" : "-1"}
+                      aria-selected=${this._activeKeypressTab === "short"}
+                      @click=${() => {
+                        this._activeKeypressTab = "short";
+                      }}
+                      @keydown=${(e: KeyboardEvent) => {
+                        if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+                          e.preventDefault();
+                          this._activeKeypressTab =
+                            this._activeKeypressTab === "short" ? "long" : "short";
+                          this.updateComplete.then(() => {
+                            const active = this.shadowRoot?.querySelector<HTMLElement>(
+                              '.tab[aria-selected="true"]',
+                            );
+                            active?.focus();
+                          });
+                        }
+                      }}
+                    >
+                      ${this._l("link_config.short_keypress")}
+                    </div>
+                    <div
+                      class="tab ${this._activeKeypressTab === "long" ? "active" : ""}"
+                      role="tab"
+                      tabindex=${this._activeKeypressTab === "long" ? "0" : "-1"}
+                      aria-selected=${this._activeKeypressTab === "long"}
+                      @click=${() => {
+                        this._activeKeypressTab = "long";
+                      }}
+                      @keydown=${(e: KeyboardEvent) => {
+                        if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+                          e.preventDefault();
+                          this._activeKeypressTab =
+                            this._activeKeypressTab === "short" ? "long" : "short";
+                          this.updateComplete.then(() => {
+                            const active = this.shadowRoot?.querySelector<HTMLElement>(
+                              '.tab[aria-selected="true"]',
+                            );
+                            active?.focus();
+                          });
+                        }
+                      }}
+                    >
+                      ${this._l("link_config.long_keypress")}
+                    </div>
                   </div>
-                  <div
-                    class="tab ${this._activeKeypressTab === "long" ? "active" : ""}"
-                    role="tab"
-                    tabindex=${this._activeKeypressTab === "long" ? "0" : "-1"}
-                    aria-selected=${this._activeKeypressTab === "long"}
-                    @click=${() => {
-                      this._activeKeypressTab = "long";
-                    }}
-                    @keydown=${(e: KeyboardEvent) => {
-                      if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
-                        e.preventDefault();
-                        this._activeKeypressTab =
-                          this._activeKeypressTab === "short" ? "long" : "short";
-                        this.updateComplete.then(() => {
-                          const active = this.shadowRoot?.querySelector<HTMLElement>(
-                            '.tab[aria-selected="true"]',
-                          );
-                          active?.focus();
-                        });
-                      }
-                    }}
-                  >
-                    ${this._l("link_config.long_keypress")}
+                  <div class="keypress-params" role="tabpanel">
+                    ${this._renderParamList(
+                      this._activeKeypressTab === "short" ? grouped.short : grouped.long,
+                    )}
                   </div>
-                </div>
-                <div class="keypress-params" role="tabpanel">
-                  ${this._renderParamList(
-                    this._activeKeypressTab === "short" ? grouped.short : grouped.long,
-                  )}
-                </div>
-              `
-            : hasShort
-              ? this._renderParamList(grouped.short)
-              : hasLong
-                ? this._renderParamList(grouped.long)
-                : nothing}
-          ${grouped.common.length > 0
-            ? html` <div class="common-params">${this._renderParamList(grouped.common)}</div> `
-            : nothing}
+                `
+              : hasShort
+                ? this._renderParamList(grouped.short)
+                : hasLong
+                  ? this._renderParamList(grouped.long)
+                  : nothing
+          }
+          ${
+            grouped.common.length > 0
+              ? html` <div class="common-params">${this._renderParamList(grouped.common)}</div> `
+              : nothing
+          }
         </div>
       `;
     }
@@ -597,11 +617,13 @@ export class HmLinkConfig extends LitElement {
             <span class="link-device-name">
               ${this.senderChannelTypeLabel || this.senderDeviceName}
             </span>
-            ${this.senderDeviceName
-              ? html`<span class="link-device-detail">
-                  ${this.senderDeviceName} &middot; ${this.senderDeviceModel}
-                </span>`
-              : nothing}
+            ${
+              this.senderDeviceName
+                ? html`<span class="link-device-detail">
+                    ${this.senderDeviceName} &middot; ${this.senderDeviceModel}
+                  </span>`
+                : nothing
+            }
             <span class="link-address">${this.senderAddress}</span>
           </div>
           <ha-icon class="link-direction-arrow" .icon=${"mdi:arrow-right"}></ha-icon>
@@ -610,11 +632,13 @@ export class HmLinkConfig extends LitElement {
             <span class="link-device-name">
               ${this.receiverChannelTypeLabel || this.receiverDeviceName}
             </span>
-            ${this.receiverDeviceName
-              ? html`<span class="link-device-detail">
-                  ${this.receiverDeviceName} &middot; ${this.receiverDeviceModel}
-                </span>`
-              : nothing}
+            ${
+              this.receiverDeviceName
+                ? html`<span class="link-device-detail">
+                    ${this.receiverDeviceName} &middot; ${this.receiverDeviceModel}
+                  </span>`
+                : nothing
+            }
             <span class="link-address">${this.receiverAddress}</span>
           </div>
         </div>
@@ -623,43 +647,49 @@ export class HmLinkConfig extends LitElement {
       ${this._error ? html`<div class="error">${this._error}</div>` : nothing}
       ${this._renderProfileSelector()}
       ${this._hasReceiverParams() ? this._renderReceiverParams() : nothing}
-      ${this._hasSenderParams()
-        ? html`
-            <div class="param-section">
-              <h3>${this._l("link_config.sender_params")}</h3>
-              <hm-config-form
-                .hass=${this.hass}
-                .schema=${this._senderSchema}
-                .pendingChanges=${this._senderPendingChanges}
-                .validationErrors=${this._senderValidationErrors}
-                @value-changed=${this._handleSenderValueChanged}
-              ></hm-config-form>
-            </div>
-          `
-        : nothing}
-      ${!this._hasReceiverParams() && !this._hasSenderParams()
-        ? html`<div class="empty-state">${this._l("link_config.no_params")}</div>`
-        : nothing}
-      ${this.editable
-        ? html`
-            <div class="action-bar action-bar-sticky">
-              <ha-button
-                outlined
-                @click=${this._handleDiscard}
-                .disabled=${!this._isDirty || this._saving}
-              >
-                ${this._l("link_config.discard")}
-              </ha-button>
-              <ha-button
-                raised
-                @click=${this._handleSave}
-                .disabled=${!this._isDirty || this._saving}
-              >
-                ${this._saving ? this._l("channel_config.saving") : this._l("common.save")}
-              </ha-button>
-            </div>
-          `
-        : nothing}
+      ${
+        this._hasSenderParams()
+          ? html`
+              <div class="param-section">
+                <h3>${this._l("link_config.sender_params")}</h3>
+                <hm-config-form
+                  .hass=${this.hass}
+                  .schema=${this._senderSchema}
+                  .pendingChanges=${this._senderPendingChanges}
+                  .validationErrors=${this._senderValidationErrors}
+                  @value-changed=${this._handleSenderValueChanged}
+                ></hm-config-form>
+              </div>
+            `
+          : nothing
+      }
+      ${
+        !this._hasReceiverParams() && !this._hasSenderParams()
+          ? html`<div class="empty-state">${this._l("link_config.no_params")}</div>`
+          : nothing
+      }
+      ${
+        this.editable
+          ? html`
+              <div class="action-bar action-bar-sticky">
+                <ha-button
+                  outlined
+                  @click=${this._handleDiscard}
+                  .disabled=${!this._isDirty || this._saving}
+                >
+                  ${this._l("link_config.discard")}
+                </ha-button>
+                <ha-button
+                  raised
+                  @click=${this._handleSave}
+                  .disabled=${!this._isDirty || this._saving}
+                >
+                  ${this._saving ? this._l("channel_config.saving") : this._l("common.save")}
+                </ha-button>
+              </div>
+            `
+          : nothing
+      }
     `;
   }
 


### PR DESCRIPTION
## Problem

The CCU tab is gated on `permissions.backend === "CCU"`.

`backend` is `central.model`. The direct-CCU (aiohomematic) backend reports `"CCU"`, but the **openccu-loom** backend — which mediates the very same CCU through the daemon and implements the same `homematicip_local/ccu/*` command surface — reports its own backend-form identity `"openccu-loom"`.

The literal comparison therefore hid the **entire CCU dashboard** (inbox, service/alarm messages, install mode, firmware, signal quality, backup, system information) from every loom-backed entry, even though the backend serves all of those commands. The dashboard was only reachable via a manual `#tab=ccu` deep-link, which bypasses the tab check.

## Fix

Gate on the *set* of backends that serve the CCU surface:

```ts
const CCU_DASHBOARD_BACKENDS: readonly string[] = ["CCU", "openccu-loom"];
...
if (CCU_DASHBOARD_BACKENDS.includes(this._permissions?.backend ?? "")) {
```

Changing `central.model` to `"CCU"` on the loom side was rejected: that value also drives entity dispatch and backend identity elsewhere.

## Companion

Pairs with openccu-loom-client PR #59, which fixes the `ccu/*` and `integration` commands themselves (record/bool return shapes) so the newly-visible dashboard actually works.

## Checks
`tsc --noEmit`, ESLint and Prettier clean; full jest suite (213 tests) green.