### PR TITLE
chore(ci): stagger Dependabot cooldown by bump type, move reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners are requested as reviewers on every pull request touching a
+# matching path — including Dependabot's. This replaces the `reviewers` key in
+# dependabot.yml, which GitHub removed on 2025-05-20.
+#
+# Syntax: <pattern>  <owner>...  (last matching pattern wins)
+
+*  @SukramJ

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# Reviewers are assigned via .github/CODEOWNERS — the `reviewers` key was
+# removed from dependabot.yml by GitHub on 2025-05-20 and is silently ignored.
 # yamllint disable-line rule:truthy
 version: 2
 updates:
@@ -5,10 +7,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Only propose releases that have been public long enough to have surfaced
+    # regressions. github-actions has no SemVer support, so the per-bump-type
+    # keys (semver-*-days) are not available here — default-days covers all bumps.
     cooldown:
-      default-days: 7
-    reviewers:
-      - "SukramJ"
+      default-days: 14
     labels:
       - "dependencies"
       - "github-actions"
@@ -23,10 +26,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Wait for a release to mature before it is proposed, scaled by blast radius:
+    # majors get the longest soak, patches the shortest. Dependabot then picks the
+    # newest version that has cleared its window rather than skipping the update.
+    # Security updates bypass cooldown entirely.
     cooldown:
       default-days: 7
-    reviewers:
-      - "SukramJ"
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
     labels:
       - "dependencies"
       - "npm"


### PR DESCRIPTION
## Summary

Two changes to how Dependabot proposes updates.

**1. Cooldown staggered by bump type**

| Ecosystem | Before | After |
| --- | --- | --- |
| `github-actions` | 7 days, flat | **14 days** |
| `npm` | 7 days, flat | patch 7 / **minor 14** / **major 30** |

The flat 7-day window treated a patch and a major the same. #80 slipped `actions/setup-node` 6.4.0 → 7.0.0 through after 11 days on that basis. Majors now soak for 30 days, minors for 14.

`github-actions` gets no per-bump-type staggering on purpose: the `semver-*-days` keys apply only to ecosystems with SemVer support, which does not include GitHub Actions, so `default-days` has to cover every bump type there.

Two properties of `cooldown` worth keeping in mind, both noted as comments in the file:

- It is a **floor, not a freeze** — Dependabot still proposes the newest version that has cleared its window, so the repo does not fall permanently behind.
- **Security updates bypass cooldown entirely**, so no CVE fix is delayed by the 30-day major window.

**2. `reviewers` → CODEOWNERS**

GitHub [removed the `reviewers` key](https://github.blog/changelog/2025-08-08-dependabot-reviewers-configuration-option-is-replaced-by-code-owners/) from `dependabot.yml` on 2025-05-20. It has been silently ignored ever since, meaning no reviewer was actually being assigned. `.github/CODEOWNERS` restores that and applies to every pull request, not just Dependabot's.

## Validation

- `dependabot.yml` validates against [`json.schemastore.org/dependabot-2.0.json`](https://json.schemastore.org/dependabot-2.0.json) (the stale `reviewers` key was the only violation before this change)
- Prettier formatting check passes

## Notes

- The auto-merge workflow is untouched and still merges non-major updates only; majors now additionally have to clear 30 days before a PR is opened at all.
- Cooldown applies at the manifest level — transitive dependencies pulled in by a lockfile update can still be fresh.
- CODEOWNERS takes effect once merged to `main`, and requires the listed account to have write access.