### PR TITLE
feat(config-panel): let the loom daemon own what it already owns

### DIFF
--- a/packages/config-panel/src/homematic-config.ts
+++ b/packages/config-panel/src/homematic-config.ts
@@ -23,13 +23,21 @@ type PermissionScope = "schedule_edit" | "device_config" | "device_links" | "sys
  * signal quality, backup, system information).
  *
  * `backend` is `central.model`. The direct-CCU (aiohomematic) backend reports
- * `"CCU"`. The openccu-loom backend mediates the very same CCU through the
- * daemon and implements the same commands, but reports its own backend-form
- * identity `"openccu-loom"` — deliberately not `"CCU"`, because that value also
- * drives entity dispatch and backend identity elsewhere. Gating on the literal
- * `"CCU"` therefore hid the whole dashboard from loom-backed entries.
+ * `"CCU"`; the openccu-loom backend reports its own identity and *could* serve
+ * this dashboard — it implements the same commands, and did serve it for a
+ * while.
+ *
+ * It is excluded again deliberately. A loom daemon brings its own Config UI,
+ * which covers inbox, firmware, signal quality, service messages and backups
+ * for **every** CCU it serves, while this dashboard only ever showed the one
+ * CCU behind the selected config entry. Two surfaces claiming the same
+ * capability — one of them narrower — is worse than one, and the loom daemon
+ * is the side that actually owns the state.
+ *
+ * Loom-backed entries keep the Devices tab, which is what Home Assistant
+ * genuinely owns: paramsets, links and schedules with native session undo/redo.
  */
-const CCU_DASHBOARD_BACKENDS: readonly string[] = ["CCU", "openccu-loom"];
+const CCU_DASHBOARD_BACKENDS: readonly string[] = ["CCU"];
 
 type PanelTab = "devices" | "integration" | "ccu";
 
@@ -416,6 +424,7 @@ export class HomematicConfigPanel extends LitElement {
             <hm-integration-dashboard
               .hass=${this.hass}
               .entryId=${this._entryId}
+              .backend=${this._permissions?.backend ?? null}
             ></hm-integration-dashboard>
           </div>`,
         )}

--- a/packages/config-panel/src/views/integration-dashboard.ts
+++ b/packages/config-panel/src/views/integration-dashboard.ts
@@ -19,12 +19,24 @@ import type {
   IncidentsResult,
   DeviceStatistics,
 } from "../panel-api";
-import { loadEntryEntityIds, getRadioLevels, dcLevelClass, csLevelClass } from "@hmip/panel-api";
+import {
+  loadEntryEntityIds,
+  getRadioLevels,
+  dcLevelClass,
+  csLevelClass,
+  BACKEND_LOOM,
+} from "@hmip/panel-api";
 
 @safeCustomElement("hm-integration-dashboard")
 export class HmIntegrationDashboard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @property() public entryId = "";
+  /**
+   * `central.model` of the selected entry, or null while permissions are
+   * still loading. Only "is this the loom backend" is read from it — see
+   * [_isLoom].
+   */
+  @property() public backend: string | null = null;
 
   @state() private _health: SystemHealthData | null = null;
   @state() private _throttle: Record<string, ThrottleStats> | null = null;
@@ -51,7 +63,25 @@ export class HmIntegrationDashboard extends LitElement {
     this._stopPolling();
   }
 
+  /**
+   * Whether the selected entry runs on the openccu-loom backend.
+   *
+   * On loom, `central` is the daemon adapter: health, command throttling and
+   * incidents are the *daemon's* state, reported through a detour, and the
+   * loom Config UI shows all three under Diagnostics — for every CCU the
+   * daemon serves, not just the one behind this entry. This view therefore
+   * drops them and keeps what Home Assistant itself knows: the radio load of
+   * this entry's own entities, and how many devices it turned into entities.
+   */
+  private get _isLoom(): boolean {
+    return this.backend === BACKEND_LOOM;
+  }
+
   private _isStableState(): boolean {
+    // Without a health payload — which loom entries never fetch — the fast
+    // interval would be the permanent choice. Their remaining cards are a
+    // device count and a radio level; neither moves in five seconds.
+    if (this._isLoom) return true;
     return (
       this._health !== null &&
       HmIntegrationDashboard._STABLE_STATES.includes(this._health.central_state)
@@ -75,22 +105,27 @@ export class HmIntegrationDashboard extends LitElement {
 
   private async _fetchAll(): Promise<void> {
     if (!this.entryId) return;
-    const isInitialLoad = this._health === null;
+    const isInitialLoad = this._deviceStats === null;
     if (isInitialLoad) {
       this._loading = true;
     }
     this._error = "";
     try {
-      const [health, throttle, incidents, deviceStats] = await Promise.all([
-        getSystemHealth(this.hass, this.entryId),
-        getCommandThrottleStats(this.hass, this.entryId),
-        getIncidents(this.hass, this.entryId),
-        getDeviceStatistics(this.hass, this.entryId),
-      ]);
-      this._health = health;
-      this._throttle = throttle;
-      this._incidents = incidents;
-      this._deviceStats = deviceStats;
+      // Loom entries skip the three daemon-state calls entirely rather than
+      // fetching what the view then discards: three websocket round-trips
+      // every poll, and a needless dependency on adapter surfaces the loom
+      // duck-type is not obliged to implement.
+      this._deviceStats = await getDeviceStatistics(this.hass, this.entryId);
+      if (!this._isLoom) {
+        const [health, throttle, incidents] = await Promise.all([
+          getSystemHealth(this.hass, this.entryId),
+          getCommandThrottleStats(this.hass, this.entryId),
+          getIncidents(this.hass, this.entryId),
+        ]);
+        this._health = health;
+        this._throttle = throttle;
+        this._incidents = incidents;
+      }
 
       if (!this._entryEntityIds) {
         await this._loadEntryEntityIds();
@@ -157,9 +192,31 @@ export class HmIntegrationDashboard extends LitElement {
       return html`<div class="error">${this._error}</div>`;
     }
 
+    if (this._isLoom) {
+      return html`
+        ${this._renderDeviceStatsCard()} ${this._renderRadioLevelsCard()}
+        ${this._renderLoomHintCard()}
+      `;
+    }
+
     return html`
       ${this._renderHealthCard()} ${this._renderDeviceStatsCard()} ${this._renderRadioLevelsCard()}
       ${this._renderThrottleCard()} ${this._renderIncidentsCard()} ${this._renderActionsCard()}
+    `;
+  }
+
+  /**
+   * Names where the dropped cards went. Without it the tab reads as a
+   * regression to anyone who saw health and throttling here before — the
+   * data did not disappear, it stopped being shown twice.
+   */
+  private _renderLoomHintCard() {
+    return html`
+      <ha-card>
+        <div class="card-content">
+          <p class="loom-hint">${this._l("integration.loom_diagnostics_hint")}</p>
+        </div>
+      </ha-card>
     `;
   }
 
@@ -182,17 +239,21 @@ export class HmIntegrationDashboard extends LitElement {
                   <ha-icon .icon=${"mdi:radio-tower"} class="radio-icon"></ha-icon>
                   <span class="radio-name">${l.name}</span>
                   <span class="radio-values">
-                    ${l.dutyCycle !== null
-                      ? html`<span class="level-${dcLevelClass(l.dutyCycle)}"
-                          >DC: ${l.dutyCycle}%</span
-                        >`
-                      : nothing}
+                    ${
+                      l.dutyCycle !== null
+                        ? html`<span class="level-${dcLevelClass(l.dutyCycle)}"
+                            >DC: ${l.dutyCycle}%</span
+                          >`
+                        : nothing
+                    }
                     ${l.dutyCycle !== null && l.carrierSense !== null ? html` · ` : nothing}
-                    ${l.carrierSense !== null
-                      ? html`<span class="level-${csLevelClass(l.carrierSense)}"
-                          >CS: ${l.carrierSense}%</span
-                        >`
-                      : nothing}
+                    ${
+                      l.carrierSense !== null
+                        ? html`<span class="level-${csLevelClass(l.carrierSense)}"
+                            >CS: ${l.carrierSense}%</span
+                          >`
+                        : nothing
+                    }
                   </span>
                 </div>
               `,
@@ -249,29 +310,33 @@ export class HmIntegrationDashboard extends LitElement {
               <span class="stat-label">${this._l("integration.firmware_updatable")}</span>
             </div>
           </div>
-          ${Object.keys(stats.by_interface).length > 1
-            ? html`
-                <div class="interface-breakdown">
-                  ${Object.entries(stats.by_interface).map(
+          ${
+            Object.keys(stats.by_interface).length > 1
+              ? html`
+                  <div class="interface-breakdown">
+                    ${Object.entries(stats.by_interface).map(
                     ([iid, data]) => html`
                       <div class="interface-row">
                         <span class="interface-name">${iid}</span>
                         <span class="interface-stats">
                           ${data.total} ${this._l("integration.total_short")}
-                          ${data.unreachable > 0
-                            ? html`,
-                                <span class="warn-text"
-                                  >${data.unreachable}
-                                  ${this._l("integration.unreachable_short")}</span
-                                >`
-                            : nothing}
+                          ${
+                            data.unreachable > 0
+                              ? html`,
+                                  <span class="warn-text"
+                                    >${data.unreachable}
+                                    ${this._l("integration.unreachable_short")}</span
+                                  >`
+                              : nothing
+                          }
                         </span>
                       </div>
                     `,
                   )}
-                </div>
-              `
-            : nothing}
+                  </div>
+                `
+              : nothing
+          }
         </div>
       </ha-card>
     `;
@@ -331,11 +396,12 @@ export class HmIntegrationDashboard extends LitElement {
           <span class="badge">${summary.total_incidents}</span>
         </div>
         <div class="card-content">
-          ${incidents.length === 0
-            ? html`<div class="empty-state">${this._l("integration.no_incidents")}</div>`
-            : html`
-                <div class="incident-list">
-                  ${incidents.map(
+          ${
+            incidents.length === 0
+              ? html`<div class="empty-state">${this._l("integration.no_incidents")}</div>`
+              : html`
+                  <div class="incident-list">
+                    ${incidents.map(
                     (inc) => html`
                       <div class="incident-row severity-${inc["severity"] ?? "info"}">
                         <span class="incident-type">${inc["type"]}</span>
@@ -346,17 +412,20 @@ export class HmIntegrationDashboard extends LitElement {
                       </div>
                     `,
                   )}
-                </div>
-              `}
-          ${incidents.length > 0
-            ? html`
-                <div class="action-bar">
-                  <ha-button class="destructive" @click=${this._handleClearIncidents}>
-                    ${this._l("integration.clear_incidents")}
-                  </ha-button>
-                </div>
-              `
-            : nothing}
+                  </div>
+                `
+          }
+          ${
+            incidents.length > 0
+              ? html`
+                  <div class="action-bar">
+                    <ha-button class="destructive" @click=${this._handleClearIncidents}>
+                      ${this._l("integration.clear_incidents")}
+                    </ha-button>
+                  </div>
+                `
+              : nothing
+          }
         </div>
       </ha-card>
     `;
@@ -574,6 +643,12 @@ export class HmIntegrationDashboard extends LitElement {
         display: flex;
         flex-direction: column;
         gap: 8px;
+      }
+
+      .loom-hint {
+        margin: 0;
+        color: var(--secondary-text-color);
+        line-height: 1.5;
       }
 
       .radio-row {

--- a/packages/config-panel/translations/de.json
+++ b/packages/config-panel/translations/de.json
@@ -325,6 +325,7 @@
     "total_short": "gesamt",
     "unreachable_short": "nicht erreichbar",
     "radio_levels": "Duty Cycle / Carrier Sense",
+    "loom_diagnostics_hint": "Systemzustand, Befehlsdrosselung und St\u00f6rungen finden Sie in der OpenCCU-Loom-Konfigurationsoberfl\u00e4che unter Diagnose \u2014 dort f\u00fcr alle CCUs des Daemons, nicht nur f\u00fcr diesen Eintrag.",
     "command_throttle": "Befehlsdrosselung",
     "enabled": "Aktiviert",
     "interval": "Intervall",

--- a/packages/config-panel/translations/en.json
+++ b/packages/config-panel/translations/en.json
@@ -325,6 +325,7 @@
     "total_short": "total",
     "unreachable_short": "unreachable",
     "radio_levels": "Duty Cycle / Carrier Sense",
+    "loom_diagnostics_hint": "System health, command throttling and incidents live in the OpenCCU-Loom Config UI under Diagnostics \u2014 there they cover every CCU the daemon serves, not just this config entry.",
     "command_throttle": "Command Throttle",
     "enabled": "Enabled",
     "interval": "Interval",

--- a/packages/panel-api/src/index.ts
+++ b/packages/panel-api/src/index.ts
@@ -44,6 +44,8 @@ export type {
   FirmwareOverview,
 } from "./types";
 
+export { BACKEND_LOOM } from "./types";
+
 // Config API
 export {
   LINKABLE_INTERFACES,

--- a/packages/panel-api/src/types.ts
+++ b/packages/panel-api/src/types.ts
@@ -268,6 +268,16 @@ export interface UserPermissions {
   backend: string | null;
 }
 
+/**
+ * `central.model` of the openccu-loom backend. The direct-CCU (aiohomematic)
+ * backend reports `"CCU"`; loom mediates the same CCU through its daemon and
+ * reports its own identity, because that value also drives entity dispatch.
+ *
+ * Lives here, next to [UserPermissions.backend], so the panel shell and the
+ * views can both compare against it without importing each other.
+ */
+export const BACKEND_LOOM = "openccu-loom";
+
 // --- Integration dashboard types ---
 
 export interface SystemHealthData {


### PR DESCRIPTION
Two tabs claimed capabilities the openccu-loom daemon serves better. Neither is removed for direct-CCU entries.

## CCU tab: gated back to the direct-CCU backend

#74 opened it to loom because the literal `"CCU"` check hid the dashboard entirely from loom-backed entries. Showing it was the wrong fix: a loom daemon ships its own Config UI that covers inbox, firmware, signal quality, service messages and backups for **every** CCU it serves, while this tab only ever showed the one CCU behind the selected config entry. Two surfaces for one capability — the visible one narrower — is worse than one, and the daemon is the side that owns the state.

## Integration tab: reduced to what Home Assistant itself knows

On loom, `ws_get_system_health` reads `control.central.health` and `ws_get_command_throttle_stats` reads `client.command_throttle` — with the loom adapter as `central`, that is **daemon state fetched through a detour**, and the daemon shows all of it under Diagnostics for every CCU rather than one.

What stays: this entry's device statistics, and the duty-cycle / carrier-sense levels read from `hass.states` for the entry's own entities. What goes: health, throttling, incidents and the cache/incident actions — with a short note in the tab saying where they went, so the change reads as a move rather than a loss.

The three websocket calls are no longer issued at all on loom entries. That saves three round-trips per poll and drops a dependency on adapter surfaces the loom duck-type is not obliged to implement — `control_unit.py` still documents one hub-coordinator gap.

The poll interval is pinned to the slow one for loom entries: `_isStableState()` keyed on the health payload, which loom no longer fetches, so the fast 5 s interval would otherwise become permanent for a device count and a radio level.

## Devices tab

Untouched on both backends. Paramsets, direct links and schedules with native session undo/redo are the surface Home Assistant genuinely owns.

## Note on multi-CCU

This is what makes the split clean rather than merely tidy: one loom daemon can serve several CCUs, and each becomes its own config entry (`_create_loom_central` passes `serial=`). A per-entry CCU dashboard therefore showed a slice; the daemon's UI shows the whole.

## Structure

`BACKEND_LOOM` moves to `@hmip/panel-api` next to `UserPermissions.backend`, so the panel shell and the views can compare against it without importing each other.

## Verification

`make lint`, `make type-check`, `make test` (213 passed). No tests were added: `config-panel` carries none today — the suite lives in `schedule-core`.