### PR TITLE
feat(config-panel): stop offering loom-backed entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the HomematicIP Local Frontend monorepo.
 
 This project does not cut a version tag per change, so entries are grouped by **date** (newest first) rather than by released version. The initial `1.0.0` baseline is retained at the end. Routine dependency bumps and CI/chore changes are omitted. Contributions from people other than the maintainer are credited with their GitHub handle next to the PR number.
 
+## 2026-08-09
+
+### Config Panel — Loom-backed entries are no longer offered
+
+Entries running on the openccu-loom backend are filtered out of the entry picker, and the integration (2.9.1) no longer registers the panel for them at all.
+
+This completes an argument the panel already made for two of its tabs: a loom daemon ships its own Config UI covering paramsets, direct links, schedules and change history — for **every** CCU it serves, not just the one behind the selected config entry. Two surfaces claiming one capability, the visible one narrower, is worse than one. Nothing the panel offered on loom is missing from the daemon's UI, including the radio load and device statistics, which it shows per interface across all CCUs.
+
+The filter is needed on this side because the panel is registered once for the whole domain: a mixed installation (one CCU entry, one loom entry) still registers it, and without the filter the loom entry would remain selectable. An entry whose backend cannot be determined is kept rather than dropped — losing a CCU entry to a transient error is the worse failure.
+
+The Integration dashboard's loom branches are gone with it: the reduced card set, the "where did these go" note, and the conditional that skipped three websocket calls. It now serves the direct-CCU backend only, which is the only backend that reaches it.
+
+Home Assistant device pages for loom entries link at the daemon's own device view instead of this panel (see integration 2.9.1).
+
 ## 2026-07-15
 
 ### Config Panel — HA Card Styling (#75, [@smoki3](https://github.com/smoki3))

--- a/packages/config-panel/src/homematic-config.ts
+++ b/packages/config-panel/src/homematic-config.ts
@@ -12,6 +12,7 @@ import "./views/device-schedule";
 import "./components/breadcrumb";
 import { localize } from "./localize";
 import { getUserPermissions } from "./api";
+import { BACKEND_LOOM } from "@hmip/panel-api";
 import type { HomeAssistant, PanelInfo, EntryInfo, UserPermissions } from "./types";
 import type { BreadcrumbItem } from "./components/breadcrumb";
 
@@ -34,8 +35,10 @@ type PermissionScope = "schedule_edit" | "device_config" | "device_links" | "sys
  * capability — one of them narrower — is worse than one, and the loom daemon
  * is the side that actually owns the state.
  *
- * Loom-backed entries keep the Devices tab, which is what Home Assistant
- * genuinely owns: paramsets, links and schedules with native session undo/redo.
+ * That argument has since been applied to the whole panel: loom-backed entries
+ * are filtered out of the entry picker (see _resolveEntryId) and the
+ * integration no longer registers the panel for them at all, so this list is
+ * now only about the direct-CCU backend.
  */
 const CCU_DASHBOARD_BACKENDS: readonly string[] = ["CCU"];
 
@@ -172,7 +175,30 @@ export class HomematicConfigPanel extends LitElement {
       .filter((e) => e.state === "loaded")
       .map((e) => ({ entry_id: e.entry_id, title: e.title }));
 
-    this._entries = loadedEntries;
+    // Loom-backed entries are not offered here. The daemon ships its own
+    // Config UI covering everything this panel does — paramsets, links,
+    // schedules, change history — and covering it for every CCU it
+    // serves rather than the one behind an entry. The integration
+    // therefore stops registering the panel for them; a mixed
+    // installation still registers it for its CCU entries, which is why
+    // the filter has to exist on this side too.
+    //
+    // The backend is per-entry and only `get_user_permissions` reports
+    // it, so this costs one call per loaded entry — a handful, once, at
+    // panel open. An entry whose call fails is kept rather than dropped:
+    // losing a CCU entry to a transient error is the worse failure.
+    this._entries = (
+      await Promise.all(
+        loadedEntries.map(async (entry) => {
+          try {
+            const perms = await getUserPermissions(this.hass, entry.entry_id);
+            return perms.backend === BACKEND_LOOM ? null : entry;
+          } catch {
+            return entry;
+          }
+        }),
+      )
+    ).filter((entry): entry is EntryInfo => entry !== null);
 
     if (this._entries.length === 1) {
       this._entryId = this._entries[0].entry_id;
@@ -424,7 +450,6 @@ export class HomematicConfigPanel extends LitElement {
             <hm-integration-dashboard
               .hass=${this.hass}
               .entryId=${this._entryId}
-              .backend=${this._permissions?.backend ?? null}
             ></hm-integration-dashboard>
           </div>`,
         )}

--- a/packages/config-panel/src/views/integration-dashboard.ts
+++ b/packages/config-panel/src/views/integration-dashboard.ts
@@ -19,24 +19,12 @@ import type {
   IncidentsResult,
   DeviceStatistics,
 } from "../panel-api";
-import {
-  loadEntryEntityIds,
-  getRadioLevels,
-  dcLevelClass,
-  csLevelClass,
-  BACKEND_LOOM,
-} from "@hmip/panel-api";
+import { loadEntryEntityIds, getRadioLevels, dcLevelClass, csLevelClass } from "@hmip/panel-api";
 
 @safeCustomElement("hm-integration-dashboard")
 export class HmIntegrationDashboard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @property() public entryId = "";
-  /**
-   * `central.model` of the selected entry, or null while permissions are
-   * still loading. Only "is this the loom backend" is read from it — see
-   * [_isLoom].
-   */
-  @property() public backend: string | null = null;
 
   @state() private _health: SystemHealthData | null = null;
   @state() private _throttle: Record<string, ThrottleStats> | null = null;
@@ -63,25 +51,7 @@ export class HmIntegrationDashboard extends LitElement {
     this._stopPolling();
   }
 
-  /**
-   * Whether the selected entry runs on the openccu-loom backend.
-   *
-   * On loom, `central` is the daemon adapter: health, command throttling and
-   * incidents are the *daemon's* state, reported through a detour, and the
-   * loom Config UI shows all three under Diagnostics — for every CCU the
-   * daemon serves, not just the one behind this entry. This view therefore
-   * drops them and keeps what Home Assistant itself knows: the radio load of
-   * this entry's own entities, and how many devices it turned into entities.
-   */
-  private get _isLoom(): boolean {
-    return this.backend === BACKEND_LOOM;
-  }
-
   private _isStableState(): boolean {
-    // Without a health payload — which loom entries never fetch — the fast
-    // interval would be the permanent choice. Their remaining cards are a
-    // device count and a radio level; neither moves in five seconds.
-    if (this._isLoom) return true;
     return (
       this._health !== null &&
       HmIntegrationDashboard._STABLE_STATES.includes(this._health.central_state)
@@ -111,21 +81,15 @@ export class HmIntegrationDashboard extends LitElement {
     }
     this._error = "";
     try {
-      // Loom entries skip the three daemon-state calls entirely rather than
-      // fetching what the view then discards: three websocket round-trips
-      // every poll, and a needless dependency on adapter surfaces the loom
-      // duck-type is not obliged to implement.
       this._deviceStats = await getDeviceStatistics(this.hass, this.entryId);
-      if (!this._isLoom) {
-        const [health, throttle, incidents] = await Promise.all([
-          getSystemHealth(this.hass, this.entryId),
-          getCommandThrottleStats(this.hass, this.entryId),
-          getIncidents(this.hass, this.entryId),
-        ]);
-        this._health = health;
-        this._throttle = throttle;
-        this._incidents = incidents;
-      }
+      const [health, throttle, incidents] = await Promise.all([
+        getSystemHealth(this.hass, this.entryId),
+        getCommandThrottleStats(this.hass, this.entryId),
+        getIncidents(this.hass, this.entryId),
+      ]);
+      this._health = health;
+      this._throttle = throttle;
+      this._incidents = incidents;
 
       if (!this._entryEntityIds) {
         await this._loadEntryEntityIds();
@@ -192,31 +156,9 @@ export class HmIntegrationDashboard extends LitElement {
       return html`<div class="error">${this._error}</div>`;
     }
 
-    if (this._isLoom) {
-      return html`
-        ${this._renderDeviceStatsCard()} ${this._renderRadioLevelsCard()}
-        ${this._renderLoomHintCard()}
-      `;
-    }
-
     return html`
       ${this._renderHealthCard()} ${this._renderDeviceStatsCard()} ${this._renderRadioLevelsCard()}
       ${this._renderThrottleCard()} ${this._renderIncidentsCard()} ${this._renderActionsCard()}
-    `;
-  }
-
-  /**
-   * Names where the dropped cards went. Without it the tab reads as a
-   * regression to anyone who saw health and throttling here before — the
-   * data did not disappear, it stopped being shown twice.
-   */
-  private _renderLoomHintCard() {
-    return html`
-      <ha-card>
-        <div class="card-content">
-          <p class="loom-hint">${this._l("integration.loom_diagnostics_hint")}</p>
-        </div>
-      </ha-card>
     `;
   }
 
@@ -315,12 +257,12 @@ export class HmIntegrationDashboard extends LitElement {
               ? html`
                   <div class="interface-breakdown">
                     ${Object.entries(stats.by_interface).map(
-                    ([iid, data]) => html`
-                      <div class="interface-row">
-                        <span class="interface-name">${iid}</span>
-                        <span class="interface-stats">
-                          ${data.total} ${this._l("integration.total_short")}
-                          ${
+                      ([iid, data]) => html`
+                        <div class="interface-row">
+                          <span class="interface-name">${iid}</span>
+                          <span class="interface-stats">
+                            ${data.total} ${this._l("integration.total_short")}
+                            ${
                             data.unreachable > 0
                               ? html`,
                                   <span class="warn-text"
@@ -329,10 +271,10 @@ export class HmIntegrationDashboard extends LitElement {
                                   >`
                               : nothing
                           }
-                        </span>
-                      </div>
-                    `,
-                  )}
+                          </span>
+                        </div>
+                      `,
+                    )}
                   </div>
                 `
               : nothing
@@ -402,16 +344,16 @@ export class HmIntegrationDashboard extends LitElement {
               : html`
                   <div class="incident-list">
                     ${incidents.map(
-                    (inc) => html`
-                      <div class="incident-row severity-${inc["severity"] ?? "info"}">
-                        <span class="incident-type">${inc["type"]}</span>
-                        <span class="incident-message">${inc["message"]}</span>
-                        <span class="incident-time"
-                          >${this._formatTimestamp(String(inc["timestamp"] ?? ""))}</span
-                        >
-                      </div>
-                    `,
-                  )}
+                      (inc) => html`
+                        <div class="incident-row severity-${inc["severity"] ?? "info"}">
+                          <span class="incident-type">${inc["type"]}</span>
+                          <span class="incident-message">${inc["message"]}</span>
+                          <span class="incident-time"
+                            >${this._formatTimestamp(String(inc["timestamp"] ?? ""))}</span
+                          >
+                        </div>
+                      `,
+                    )}
                   </div>
                 `
           }


### PR DESCRIPTION
## What

Entries running on the **openccu-loom** backend are filtered out of the panel's entry picker. The integration (2.9.1, PR pending) stops registering the panel for them at all.

## Why — the argument this repo already made

2.9.1 retired the **CCU** tab and reduced the **Integration** tab on loom, with this reasoning:

> A loom daemon brings its own Config UI, which covers inbox, firmware, signal quality, service messages and backups for **every** CCU it serves, while this dashboard only ever showed the one CCU behind the selected config entry. Two surfaces claiming the same capability — one of them narrower — is worse than one.

That argument does not stop at two tabs. Everything the panel still offered on loom is in the daemon's UI:

| Panel view | Daemon equivalent |
|---|---|
| device-list / device-detail / channel-config | device list + Configure tabs |
| device-links / add-link / link-config | device → Links, plus a fleet-wide `/links` |
| device-schedule | device → Schedule, plus a fleet-wide `/schedules` |
| change-history | Settings → Changed settings |
| Integration: radio levels | Diagnostics — `duty_cycle` / `carrier_sense` **per interface, all CCUs** |
| Integration: device statistics | Fleet (per CCU), plus `/firmware` and the unreachable filters |

The last two are the ones I initially thought were exclusive to this panel. They are not — the panel scopes them to one config entry's entities, the daemon shows them across the fleet. Scope is not content, and the narrower scope is the one being dropped.

## Why the filter is needed here too

The panel is registered **once for the whole domain**. A mixed installation — one CCU entry, one loom entry — still registers it, and without this filter the loom entry would stay selectable.

The backend is per-entry and only `get_user_permissions` reports it, so this costs one call per loaded entry, once, at panel open. An entry whose call fails is **kept**, not dropped: losing a CCU entry to a transient error is the worse failure.

## Also removed

The Integration dashboard's loom branches — the reduced card set, the "where did these go" note, the conditional that skipped three websocket calls per poll, and the `backend` property that fed them. It serves the direct-CCU backend only now, which is the only backend that reaches it.

## Not covered by tests

This package has **no test harness** — of seven packages only `schedule-core` has tests — so the filter is verified by build and type-check alone. The tested guard is on the integration side (five cases incl. the mixed installation), which is also the one that matters for the common single-backend case. Standing up a suite for `config-panel` is worth doing, but not inside this change.

## Verification

`npm run validate` (lint + type-check + test + build) exits 0; 213 tests pass. The built bundle is deployed to the integration repo and ships in its PR.
