### PR TITLE
fix(config-panel): a deep link cannot re-select a dropped entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project does not cut a version tag per change, so entries are grouped by **
 
 ## 2026-08-09
 
+### Config Panel — A deep link cannot re-select a dropped entry
+
+`entry=` in the URL hash was applied without checking it against the entries the panel serves. After #89 that reopened the hole it closed: a bookmark, or a device page's `configuration_url` written before loom entries were dropped — which Home Assistant keeps in the device registry until those entities re-register — put the panel straight back onto a loom entry. In a mixed installation exactly one entry remains, so the picker is hidden and nothing on screen would have shown it had happened.
+
+An unserved entry id is now ignored, and the rest of the link with it: its device and channel addresses mean nothing under the entry that was kept, so the panel lands on that entry's device list instead of failing later as "not found".
+
 ### Config Panel — Loom-backed entries are no longer offered
 
 Entries running on the openccu-loom backend are filtered out of the entry picker, and the integration (2.9.1) no longer registers the panel for them at all.

--- a/packages/config-panel/src/homematic-config.ts
+++ b/packages/config-panel/src/homematic-config.ts
@@ -116,8 +116,26 @@ export class HomematicConfigPanel extends LitElement {
     const senderAddress = params.get("sender") || "";
     const receiverAddress = params.get("receiver") || "";
 
-    if (entryId) this._entryId = entryId;
+    // Only an entry this panel actually serves. A URL can name any id —
+    // an old bookmark, or a device page's `configuration_url` written
+    // before loom entries were dropped, which Home Assistant keeps in
+    // the device registry until those entities re-register. Honouring it
+    // would put the panel back on an entry it no longer offers, and with
+    // a single remaining entry the picker is hidden, so nothing on screen
+    // would show that it had happened.
+    const servesEntry = !entryId || this._entries.some((e) => e.entry_id === entryId);
+    if (entryId && servesEntry) {
+      this._entryId = entryId;
+    }
     if (tab) this._tab = tab;
+    // The rest of the link belongs to the rejected entry: its device and
+    // channel addresses mean nothing under the entry we kept, and opening
+    // them there would fail as "not found" instead of saying why. Land on
+    // the device list of the entry this panel does serve.
+    if (!servesEntry) {
+      this._navigateTo("device-list", {});
+      return;
+    }
     if (view) {
       this._navigateTo(view, {
         device,


### PR DESCRIPTION
Follow-up to #89, which closed this on the picker path and left it open on the other one.

## The gap

`_parseUrlHash` applied `entry=` from the URL **without** checking it against the entries the panel serves — and it runs *after* `_resolveEntryId`, plus again on every `popstate`.

So in a mixed installation (one CCU entry, one loom entry) the picker correctly offered only the CCU entry, while a URL naming the loom entry put the panel straight onto it.

That URL is not hypothetical. Home Assistant keeps `configuration_url` in the device registry, so existing loom device entries carry the **old** panel deep link — with their entry id — until their entities re-register. The first click after upgrading could have been one.

And it would have been invisible: exactly one entry survives the filter, so `_entries.length <= 1` hides the picker. Nothing on screen would have shown which entry the panel was on.

## The fix

An unserved entry id is ignored, and the rest of the link with it — its device and channel addresses mean nothing under the entry that was kept, and opening them there fails as "not found" rather than saying why. The panel lands on the device list of the entry it does serve.

## Verification

`npm run validate` (lint + type-check + test + build) exits 0.

Still unverified by tests: this package has no test harness (only `schedule-core` has one), which is why this needed reading rather than a failing test to surface.