### PR TITLE
test: add a Vitest harness for the config panel, cards and shared UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This project does not cut a version tag per change, so entries are grouped by **
 
 ## 2026-08-09
 
+### Tests for the config panel, the cards and the shared UI
+
+Everything but `schedule-core` was untested — roughly 11k lines in the config panel alone, and the packages carrying all the user-facing behaviour. They now have a test setup and 142 tests across all six of them.
+
+They run on **Vitest 4**, not on the existing Jest. Lit 3 ships ESM only, which Jest can load solely behind `--experimental-vm-modules`, and mocking under that flag needs `jest.unstable_mockModule` plus dynamic imports in every file. `schedule-core` keeps its Jest suite: it imports no Lit, its 213 tests pass unchanged, and rewriting them would buy nothing. `make test` runs both.
+
+The seam that makes this cheap is one the code already had: every API call in every package goes through `hass.callWS()`. A fake `hass` from the new `@hmip/test-utils` therefore replaces the backend without mocking a single module. A command with no registered response rejects with a message naming it, so a forgotten stub fails where it happens rather than as a confusing render error three steps later.
+
+`test-utils/` also carries the DOM helpers (`mount` waits out Lit's render and throws on an unregistered tag, `textOf` strips the `<style>` element jsdom forces Lit to inject), stand-ins for the `ha-*` elements Home Assistant provides at runtime, and typed fixture builders whose return types come from `@hmip/panel-api` — so a backend contract change breaks the fixtures at compile time instead of producing silently wrong test data.
+
+Package aliases resolve to sources rather than `dist/`, so tests need no build first and fail against the code as written. Test files are excluded from every build tsconfig and type-checked by the new `tsconfig.test.json`, which `make type-check` now runs too.
+
+New targets: `make test-core`, `make test-vitest`, `make test-pkg PKG=<name>`, `make test-coverage` (Vitest) and `make test-coverage-core` (Jest). `make test-watch` now watches the Vitest suites; the old schedule-core watcher is `make test-watch-core`.
+
 ### Config Panel — A deep link cannot re-select a dropped entry
 
 `entry=` in the URL hash was applied without checking it against the entries the panel serves. After #89 that reopened the hole it closed: a bookmark, or a device page's `configuration_url` written before loom entries were dropped — which Home Assistant keeps in the device registry until those entities re-register — put the panel straight back onto a loom entry. In a mixed installation exactly one entry remains, so the picker is hidden and nothing on screen would have shown it had happened.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This document provides comprehensive context for AI assistants working with the 
 **Primary Language**: TypeScript 5.9+
 **Framework**: Lit 3.0 (Web Components)
 **Build System**: TypeScript compiler (schedule-core, schedule-ui) + Rollup (cards, config panel)
-**Testing**: Jest 30 with ts-jest
+**Testing**: Vitest 4 + jsdom (every Lit package), Jest 30 with ts-jest (schedule-core)
 **Linting**: ESLint 9 (flat config) + Prettier
 **Git Hooks**: Husky + lint-staged
 
@@ -115,12 +115,21 @@ homematicip-local-frontend/
 ├── .github/workflows/
 │   ├── ci.yml                              # GitHub Actions CI
 │   └── release.yml                         # Release pipeline (on card tags)
+├── test-utils/                             # Shared test helpers (alias @hmip/test-utils)
+│   ├── index.ts                            # Re-exports
+│   ├── setup.ts                            # jsdom polyfills, ha-* stubs, DOM cleanup
+│   ├── hass.ts                             # createHass, hassEntity, statesOf
+│   ├── dom.ts                              # mount, query helpers, textOf, eventSpy
+│   ├── ha-stubs.ts                         # Stand-ins for HA's ha-* elements
+│   └── fixtures.ts                         # Typed backend payload builders
 ├── tsconfig.base.json                      # Shared TypeScript base config
+├── tsconfig.test.json                      # Type-checks test-utils and the *.test.ts files
 ├── eslint.config.mjs                       # ESLint 9 flat config
 ├── .prettierrc                             # Prettier config
 ├── .editorconfig                           # EditorConfig
 ├── .gitignore
-├── jest.config.js                          # Root Jest config (projects)
+├── jest.config.js                          # Root Jest config (schedule-core project)
+├── vitest.config.ts                        # Vitest projects for the Lit packages
 └── package.json                            # Workspace root
 ```
 
@@ -409,40 +418,112 @@ Output: Single ES module `.js` file per card (all dependencies bundled, no exter
 
 ## Testing
 
-### Framework
+### Two Runners, One Reason
 
-- **Jest 30** with `ts-jest` preset and `jsdom` environment
-- Tests co-located with source: `*.test.ts` next to `*.ts`
-- Root `jest.config.js` uses `projects` to run across packages
+- **Vitest 4** (`vitest.config.ts`) — every package that imports Lit
+- **Jest 30** with `ts-jest` (`packages/schedule-core/jest.config.js`) — `schedule-core` only
+
+The split is not a preference. Lit 3 ships ESM only, which Jest can load solely
+through `--experimental-vm-modules`, and mocking under that flag requires
+`jest.unstable_mockModule` plus dynamic imports in every file. Vitest is
+ESM-native, so the Lit packages run there. `schedule-core` imports no Lit, its
+213 tests pass under ts-jest' CommonJS transform, and rewriting them would buy
+nothing — so it stays.
+
+Both runners use `jsdom` and co-locate tests with the source: `*.test.ts` next
+to `*.ts`.
 
 ### Running Tests
 
 ```bash
-make test                   # All tests (via workspace)
-make test-watch             # schedule-core tests in watch mode
+make test                   # Everything: Jest (schedule-core) then Vitest
+make test-core              # schedule-core only (Jest)
+make test-vitest            # The Lit packages only (Vitest)
+make test-pkg PKG=config-panel   # A single Vitest project
+make test-watch             # Vitest in watch mode
+make test-watch-core        # schedule-core in watch mode
 ```
 
 ### Coverage
 
 ```bash
-make test-coverage          # schedule-core with coverage report
+make test-coverage          # Vitest, v8 provider → coverage/index.html
+make test-coverage-core     # Jest, schedule-core
 ```
 
-Coverage collected from `src/**/*.ts`, excluding `.d.ts`, `.test.ts`, and `index.ts`.
+Coverage is collected from `src/**/*.ts`, excluding `.d.ts`, `.test.ts`,
+`index.ts` and the style modules.
+
+### Shared Test Helpers (`test-utils/`)
+
+Imported through the `@hmip/test-utils` alias. Root-level rather than a
+workspace package, so it stays out of `build`, `type-check --workspaces` and the
+release scripts.
+
+| Module        | Provides                                                                                |
+| ------------- | --------------------------------------------------------------------------------------- |
+| `hass.ts`     | `createHass()`, `hassEntity()`, `statesOf()`                                            |
+| `dom.ts`      | `mount()`, `update()`, `click()`, `query*()`, `deepQuery*()`, `textOf()`, `eventSpy()`  |
+| `ha-stubs.ts` | `registerHaStubs()`, `selectOption()`, `setChecked()`, `setValue()`, `optionsOf()`      |
+| `fixtures.ts` | `deviceInfo()`, `channelInfo()`, `formSchema()`, `formParameter()`, `userPermissions()` |
+| `setup.ts`    | jsdom polyfills, HA stub registration, per-test DOM cleanup (loaded automatically)      |
+
+**`createHass()` is the whole seam.** Every API call in every package goes
+through `hass.callWS()`, so a fake `hass` replaces the backend without mocking a
+single module:
+
+```ts
+const hass = createHass({ ws: { "homematicip_local/config/list_devices": { devices: [deviceInfo()] } } });
+const list = await mount<HmDeviceList>("hm-device-list", { hass, entryId: "entry-1" });
+
+expect(hass.lastSent("homematicip_local/config/list_devices")).toEqual({ ... });
+```
+
+A command with no registered response **rejects with a message naming the type**,
+so a forgotten stub fails where it happens instead of surfacing later as an
+unrelated render error. Use `hass.respond()` to change a response mid-test and
+`hass.failWith()` to exercise error paths.
+
+The fake is built on the wider `@hmip/schedule-core` `HomeAssistant` shape, which
+structurally satisfies the `@hmip/panel-api` one — the panel reads
+`config.language`, the cards read `language` / `locale.language`, and one helper
+serves both.
+
+### Things That Bite
+
+- **`mount()` throws on an unregistered tag.** Almost always a missing
+  side-effect import (`import "./device-list"`). An unregistered element would
+  otherwise render as a silently empty `HTMLElement`.
+- **jsdom has no `adoptedStyleSheets`**, so Lit injects a `<style>` element into
+  the shadow root. `textOf()` strips it; raw `textContent` returns the CSS too.
+- **`registerHaStubs()` defines `ha-list-virtualized`**, which makes
+  `hm-device-list` take its virtualized branch above 100 devices. The stub
+  renders no rows, so list tests should stay under that threshold.
+- **Aliases resolve to sources, not `dist/`.** Tests never need a build first,
+  and they fail against the code as written rather than as last compiled.
+- **Test files are excluded from every build tsconfig**, so they never reach
+  `dist/`. They are type-checked by `tsconfig.test.json` instead
+  (`npm run type-check:tests`, part of `make type-check`). `exclude` globs do not
+  traverse `../`, which is why `status-card` lists the sibling test paths
+  explicitly.
 
 ### Current Test Coverage
 
-9 test suites, 187 tests covering:
+**schedule-core (Jest)** — 9 suites, 213 tests: `utils/time`, `utils/colors`,
+`utils/device-address`, `utils/device-helpers`, `utils/history`,
+`utils/validation`, `utils/converters`, `localization/localization`,
+`models/types`.
 
-- `utils/time.test.ts` - Time formatting, parsing, conversion
-- `utils/colors.test.ts` - Temperature colors and gradients
-- `utils/device-address.test.ts` - Device address parsing
-- `utils/device-helpers.test.ts` - 57 tests: entry helpers, schedule conversion, formatting
-- `utils/history.test.ts` - UndoRedoHistory (push, undo, redo, limits, clear)
-- `utils/validation.test.ts` - 37 tests: time blocks, weekday data, profile data validation
-- `utils/converters.test.ts` - Schedule parsing, conversion, merging, sorting
-- `localization/localization.test.ts` - 25 tests: translations (en/de), formatting, domain labels
-- `models/types.test.ts` - Constants and type structure validation
+**Lit packages (Vitest)** — 12 files, 142 tests:
+
+| Package                 | Suites                                                                         | Covers                                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `panel-api`             | `radio-levels`, `config-api`                                                   | Level pairing/filtering/severity, WS message shape, response unwrapping                            |
+| `schedule-ui`           | `schedule-grid`                                                                | Weekday columns, gap filling, copy/paste events, read-only mode                                    |
+| `config-panel`          | `localize`, `unsaved-guard`, `safe-element`, `breadcrumb`, `views/device-list` | Translation fallbacks, navigation-click matrix, duplicate registration, grouping/sort/search/retry |
+| `climate-schedule-card` | `localization`, `card`                                                         | Language normalization, `setConfig` forms, render error branches                                   |
+| `schedule-card`         | `card`                                                                         | Stub config, entity compatibility, loading state                                                   |
+| `status-card`           | `helpers`                                                                      | Config-entry options, graceful failure                                                             |
 
 ## Development Workflow
 
@@ -461,12 +542,14 @@ make build                # Build all packages (core → ui → cards/panel)
 make build-core           # Build schedule-core only
 make build-ui             # Build schedule-ui only (builds schedule-core first)
 make build-libs           # Build all libraries (core, ui, panel-api)
-make test                 # Run all tests
+make test                 # Run all tests (Jest for schedule-core, Vitest for the rest)
+make test-vitest          # Vitest suites only
+make test-pkg PKG=<name>  # One Vitest project
 make lint                 # ESLint check
 make lint-fix             # ESLint auto-fix
 make format               # Prettier format
 make format-check         # Prettier check
-make type-check           # TypeScript check (all packages)
+make type-check           # TypeScript check (all packages + the test files)
 make validate             # Full pipeline: lint + type-check + test + build
 make ci                   # What GitHub Actions runs (clean install first)
 make versions             # Show the current version of every package
@@ -512,6 +595,16 @@ Runs on push/PR to `main`:
 2. Add English text in `packages/schedule-core/src/localization/en.ts`
 3. Add German text in `packages/schedule-core/src/localization/de.ts`
 4. For card-specific strings, add to the card's `src/localization.ts` instead
+
+### Adding a Test to a Lit Package
+
+1. Create `<module>.test.ts` next to the module (any package but `schedule-core`)
+2. Import the helpers from `@hmip/test-utils` and the component for its side effect:
+   `import "./device-list";`
+3. Build the backend with `createHass({ ws: { "<command type>": <response> } })` —
+   register every command the code under test sends, or it will reject
+4. `await mount<T>(tag, props)`, assert with `query*` / `textOf` / `eventSpy`
+5. `make test-pkg PKG=<package>` while iterating, `make validate` before committing
 
 ### Modifying a Schedule UI Component
 
@@ -751,7 +844,7 @@ These rules govern how AI assistants must approach all code changes in this proj
 
 1. **Always run `make validate`** before suggesting code changes
 2. **Build order matters**: `schedule-core` → `schedule-ui` → card/panel packages
-3. **Tests are in schedule-core only** - UI and card packages have no tests yet
+3. **Two test runners**: `schedule-core` on Jest, every Lit package on Vitest — a new `*.test.ts` outside `schedule-core` belongs to Vitest and gets its `hass` from `createHass()`, never from a module mock
 4. **Import from `@hmip/schedule-core`** for logic/types, **`@hmip/schedule-ui`** for UI components — never use relative paths to other package source
 5. **Both EN and DE translations required** for all user-facing strings
 6. **Two schedule models exist**: climate (time-slot based) and device (event-based) - don't confuse them

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ NPM ?= npm
 # Version bump level for the version-* targets: patch | minor | major
 BUMP ?= patch
 
+# Package name for the test-pkg target, e.g. PKG=config-panel
+PKG ?=
+
 # npm writes this file on every install; using it as a sentinel means a fresh
 # clone bootstraps itself and repeated builds skip the install.
 NODE_MODULES := node_modules/.package-lock.json
@@ -59,19 +62,40 @@ format-check: $(NODE_MODULES) ## Check formatting without writing
 	$(NPM) run format:check
 
 .PHONY: type-check
-type-check: $(NODE_MODULES) ## TypeScript check across all packages
+type-check: $(NODE_MODULES) ## TypeScript check across all packages and the tests
 	$(NPM) run type-check
 
 .PHONY: test
-test: $(NODE_MODULES) ## Run all tests
+test: $(NODE_MODULES) ## Run all tests (Jest for schedule-core, Vitest for the rest)
 	$(NPM) test
 
+.PHONY: test-core
+test-core: $(NODE_MODULES) ## Run the schedule-core suite (Jest)
+	$(NPM) run test:jest
+
+.PHONY: test-vitest
+test-vitest: $(NODE_MODULES) ## Run the Lit package suites (Vitest)
+	$(NPM) run test:vitest
+
+.PHONY: test-pkg
+test-pkg: $(NODE_MODULES) ## Run one package's Vitest project (PKG=config-panel)
+	@test -n "$(PKG)" || { echo "PKG is required, e.g. make test-pkg PKG=config-panel"; exit 1; }
+	npx vitest run --project $(PKG)
+
 .PHONY: test-watch
-test-watch: $(NODE_MODULES) ## Run schedule-core tests in watch mode
+test-watch: $(NODE_MODULES) ## Run the Vitest suites in watch mode
+	$(NPM) run test:watch
+
+.PHONY: test-watch-core
+test-watch-core: $(NODE_MODULES) ## Run the schedule-core suite in watch mode
 	$(NPM) test -w packages/schedule-core -- --watch
 
 .PHONY: test-coverage
-test-coverage: $(NODE_MODULES) ## Run schedule-core tests with coverage report
+test-coverage: $(NODE_MODULES) ## Vitest coverage for the Lit packages (coverage/index.html)
+	$(NPM) run test:coverage
+
+.PHONY: test-coverage-core
+test-coverage-core: $(NODE_MODULES) ## Jest coverage for schedule-core
 	npx jest --coverage -w packages/schedule-core
 
 .PHONY: validate

--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ make build              # Build all packages
 make build-core         # Build only schedule-core
 make build-ui           # Build only schedule-ui (builds schedule-core first)
 make build-libs         # Build all libraries (core, ui, panel-api)
-make test               # Run all tests
-make test-watch         # schedule-core tests in watch mode
-make test-coverage      # schedule-core tests with coverage report
+make test               # Run all tests (Jest for schedule-core, Vitest for the Lit packages)
+make test-vitest        # Only the Vitest suites
+make test-pkg PKG=<name>  # A single Vitest project, e.g. PKG=config-panel
+make test-watch         # Vitest suites in watch mode
+make test-coverage      # Vitest coverage report (coverage/index.html)
 make lint               # ESLint
 make lint-fix           # ESLint with auto-fix
 make format             # Prettier formatting

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -342,16 +342,27 @@ Tag: climate-v*, schedule-v*, config-panel-v*, status-card-v*
 
 ## Testing Architecture
 
+Two runners, split along one line: whether the package imports Lit.
+
 ```
-jest.config.js (root)
-  │
-  │  projects: ["<rootDir>/packages/schedule-core"]
-  │
-  ▼
-packages/schedule-core/src/**/*.test.ts
+jest.config.js (root)                     vitest.config.ts (root)
+  │                                         │
+  │  projects: [schedule-core]              │  projects: panel-api, schedule-ui,
+  │                                         │            config-panel, climate-schedule-card,
+  ▼                                         │            schedule-card, status-card
+packages/schedule-core/src/**/*.test.ts     │
+  213 tests                                 │  resolve.alias: @hmip/* → packages/*/src
+                                            │  setupFiles:   test-utils/setup.ts
+                                            ▼
+                                          packages/<pkg>/src/**/*.test.ts
+                                            142 tests
 ```
 
-Tests are co-located with source files in `schedule-core`. UI and card packages rely on `schedule-core` being well-tested. 208 tests covering time utilities, color mapping, converters, validation, device helpers, history, and localization.
+Lit 3 is ESM-only, which Jest reaches only through `--experimental-vm-modules`; Vitest is ESM-native, so the Lit packages run there. `schedule-core` imports no Lit and stays on ts-jest. Tests are co-located with their source in both.
+
+The aliases point at `src`, not `dist`, so a suite runs against the current code without a build. `test-utils/` (aliased as `@hmip/test-utils`) supplies the fake `hass`, the Lit mount/query helpers, the `ha-*` element stubs and typed payload fixtures. Because every package reaches the backend through `hass.callWS()`, that fake is the only substitution the tests need — no module mocking anywhere.
+
+Test files are excluded from every build tsconfig and type-checked separately by `tsconfig.test.json`.
 
 ## Localization Architecture
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,14 +5,14 @@ export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    files: ["packages/*/src/**/*.ts"],
+    files: ["packages/*/src/**/*.ts", "test-utils/**/*.ts", "*.ts"],
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: "module",
     },
   },
   {
-    files: ["packages/*/src/**/*.ts"],
+    files: ["packages/*/src/**/*.ts", "test-utils/**/*.ts", "*.ts"],
     rules: {
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,34 +16,72 @@
       ],
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.8.0",
         "husky": "^9.1.7",
+        "jsdom": "^27.4.0",
         "lint-staged": "^17.2.0",
         "prettier": "^3.9.6",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.65.0"
+        "typescript-eslint": "^8.65.0",
+        "vitest": "^4.1.10"
       }
     },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true
+    },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "ISC"
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -562,9 +600,9 @@
       "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
       "dev": true,
       "funding": [
         {
@@ -576,15 +614,14 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
       "dev": true,
       "funding": [
         {
@@ -596,19 +633,18 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
       "dev": true,
       "funding": [
         {
@@ -620,23 +656,22 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "dev": true,
       "funding": [
         {
@@ -648,18 +683,41 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "dev": true,
       "funding": [
         {
@@ -671,9 +729,8 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -836,6 +893,23 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hmip/climate-schedule-card": {
@@ -1468,9 +1542,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1499,6 +1570,15 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
@@ -1511,6 +1591,236 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "29.0.3",
@@ -1772,9 +2082,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1789,9 +2096,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1806,9 +2110,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1823,9 +2124,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1840,9 +2138,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1857,9 +2152,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1874,9 +2166,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1891,9 +2180,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1908,9 +2194,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1925,9 +2208,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1942,9 +2222,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1959,9 +2236,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1976,9 +2250,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2096,6 +2367,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2151,6 +2428,22 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -2620,9 +2913,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2637,9 +2927,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2654,9 +2941,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2671,9 +2955,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2688,9 +2969,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2705,9 +2983,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2722,9 +2997,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2739,9 +3011,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2756,9 +3025,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2773,9 +3039,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2857,6 +3120,160 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -2885,7 +3302,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -2985,6 +3401,41 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "30.4.1",
@@ -3108,12 +3559,20 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -3225,6 +3684,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3365,12 +3833,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
       "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^3.2.0",
         "rrweb-cssom": "^0.8.0"
@@ -3379,18 +3859,155 @@
         "node": ">=18"
       }
     },
-    "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+    "node_modules/cssstyle/node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/debug": {
@@ -3448,6 +4065,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -3519,6 +4145,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3769,6 +4401,15 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4023,16 +4664,15 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/html-escaper": {
@@ -4047,7 +4687,6 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -4061,7 +4700,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -4101,7 +4739,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -4557,6 +5194,134 @@
         }
       }
     },
+    "node_modules/jest-environment-jsdom/node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
@@ -4941,11 +5706,10 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4955,35 +5719,34 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
+        "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
+        "tough-cookie": "^6.0.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
+        "webidl-conversions": "^8.0.0",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -4992,6 +5755,54 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -5080,6 +5891,255 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lines-and-columns": {
@@ -5187,6 +6247,17 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -5219,6 +6290,12 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5279,6 +6356,24 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -5354,8 +6449,20 @@
       "version": "2.2.24",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
       "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
-      "license": "MIT"
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/onetime": {
       "version": "5.1.2",
@@ -5519,6 +6626,12 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5616,6 +6729,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -5726,6 +6867,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -5769,6 +6919,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "dev": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.143.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
     },
     "node_modules/rollup": {
@@ -5821,15 +7003,13 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -5890,6 +7070,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -5923,6 +7109,15 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5967,6 +7162,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -6147,6 +7354,12 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -6174,25 +7387,32 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
       "dependencies": {
-        "tldts-core": "^6.1.86"
+        "tldts-core": "^7.4.10"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "dev": true,
-      "license": "MIT"
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -6202,29 +7422,27 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^6.1.32"
+        "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6501,6 +7719,172 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -6525,13 +7909,12 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -6540,7 +7923,6 @@
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -6553,23 +7935,21 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/which": {
@@ -6586,6 +7966,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -6651,11 +8047,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -15,12 +15,17 @@
     "build": "npm run build --workspaces --if-present",
     "build:core": "npm run build -w packages/schedule-core",
     "build:ui": "npm run build -w packages/schedule-ui",
-    "test": "npm run test --workspaces --if-present",
+    "test": "npm run test:jest && npm run test:vitest",
+    "test:jest": "npm run test --workspaces --if-present",
+    "test:vitest": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "format": "prettier --write \"packages/*/src/**/*.{ts,js}\" \"*.{json,md,mjs}\"",
-    "format:check": "prettier --check \"packages/*/src/**/*.{ts,js}\" \"*.{json,md,mjs}\"",
-    "type-check": "npm run type-check --workspaces --if-present",
+    "format": "prettier --write \"packages/*/src/**/*.{ts,js}\" \"test-utils/**/*.ts\" \"*.{ts,json,md,mjs}\"",
+    "format:check": "prettier --check \"packages/*/src/**/*.{ts,js}\" \"test-utils/**/*.ts\" \"*.{ts,json,md,mjs}\"",
+    "type-check": "npm run type-check --workspaces --if-present && npm run type-check:tests",
+    "type-check:tests": "tsc --noEmit -p tsconfig.test.json",
     "validate": "npm run lint && npm run type-check && npm run test && npm run build",
     "clean": "rm -rf packages/*/dist packages/*/*.tsbuildinfo",
     "deploy:climate": "scripts/deploy.sh climate-schedule-card",
@@ -55,15 +60,19 @@
   "overrides": {
     "handlebars": "^4.7.9",
     "glob": "^13.0.6",
-    "test-exclude": "^8.0.0"
+    "test-exclude": "^8.0.0",
+    "brace-expansion": "^5.0.9"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.8.0",
     "husky": "^9.1.7",
+    "jsdom": "^27.4.0",
     "lint-staged": "^17.2.0",
     "prettier": "^3.9.6",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.65.0"
+    "typescript-eslint": "^8.65.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/climate-schedule-card/src/card.test.ts
+++ b/packages/climate-schedule-card/src/card.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createHass,
+  hassEntity,
+  mount,
+  optionsOf,
+  query,
+  queryOrThrow,
+  statesOf,
+  textOf,
+  update,
+} from "@hmip/test-utils";
+import { WEEKDAYS } from "@hmip/schedule-core";
+
+import { HomematicScheduleCard } from "./card";
+
+const CARD = "homematicip-local-climate-schedule-card";
+
+const scheduleData = Object.fromEntries(
+  WEEKDAYS.map((weekday) => [
+    weekday,
+    {
+      base_temperature: 17,
+      periods: [{ starttime: "06:00", endtime: "09:00", temperature: 21.5 }],
+    },
+  ]),
+);
+
+const thermostat = (entityId: string, attributes: Record<string, unknown> = {}) =>
+  hassEntity(entityId, "heat", {
+    friendly_name: "Living Room",
+    active_profile: "P1",
+    available_profiles: ["P1", "P2"],
+    schedule_data: scheduleData,
+    ...attributes,
+  });
+
+/** Mount the card with a config applied, the way Lovelace does. */
+async function mountCard(
+  config: Record<string, unknown>,
+  states: Record<string, ReturnType<typeof hassEntity>> = statesOf(thermostat("climate.living")),
+): Promise<HomematicScheduleCard> {
+  const card = await mount<HomematicScheduleCard>(CARD);
+  card.setConfig(config as never);
+  await update(card, { hass: createHass({ states }) as never });
+  return card;
+}
+
+describe("climate schedule card", () => {
+  it("registers itself under the Lovelace card type", () => {
+    expect(customElements.get(CARD)).toBeDefined();
+  });
+
+  it("announces itself to the card picker", () => {
+    expect(window.customCards?.some((card) => card.type === CARD)).toBe(true);
+  });
+
+  describe("getStubConfig", () => {
+    it("preselects a climate entity that carries schedule data", () => {
+      const hass = createHass({
+        states: statesOf(
+          hassEntity("climate.without_schedule", "heat"),
+          thermostat("climate.living"),
+        ),
+      });
+
+      expect(HomematicScheduleCard.getStubConfig(hass as never)).toEqual({
+        type: `custom:${CARD}`,
+        entities: ["climate.living"],
+      });
+    });
+
+    it("yields an empty card when nothing schedulable exists", () => {
+      const hass = createHass({ states: statesOf(hassEntity("light.kitchen")) });
+
+      expect(HomematicScheduleCard.getStubConfig(hass as never)).toEqual({
+        type: `custom:${CARD}`,
+        entities: [],
+      });
+    });
+  });
+
+  it("renders nothing before Lovelace supplies a config", async () => {
+    const card = await mount<HomematicScheduleCard>(CARD);
+
+    expect(textOf(card)).toBe("");
+  });
+
+  it("renders the schedule grid for a thermostat", async () => {
+    const card = await mountCard({ entity: "climate.living" });
+
+    expect(query(card, "hmip-schedule-grid")).not.toBeNull();
+  });
+
+  it("names the card after the entity", async () => {
+    const card = await mountCard({ entity: "climate.living" });
+
+    expect(textOf(card)).toContain("Living Room");
+  });
+
+  it("prefers an explicitly configured name", async () => {
+    const card = await mountCard({ entity: "climate.living", name: "Upstairs" });
+
+    expect(textOf(card)).toContain("Upstairs");
+  });
+
+  it("reports an entity that is not in the state machine", async () => {
+    const card = await mountCard({ entity: "climate.missing" }, {});
+
+    expect(textOf(card)).toContain("Entity climate.missing not found");
+  });
+
+  it("reports a thermostat that exposes no schedule", async () => {
+    const card = await mountCard(
+      { entity: "climate.living" },
+      statesOf(thermostat("climate.living", { schedule_data: undefined })),
+    );
+
+    expect(textOf(card)).toContain("does not provide schedule data");
+  });
+
+  it("rejects a sensor whose schedule is not a climate schedule", async () => {
+    const card = await mountCard(
+      { entity: "sensor.switch_schedule" },
+      statesOf(
+        hassEntity("sensor.switch_schedule", "on", {
+          schedule_type: "switch",
+          schedule_data: scheduleData,
+        }),
+      ),
+    );
+
+    expect(textOf(card)).toContain("does not have a climate schedule type");
+  });
+
+  it("translates the error into the Home Assistant language", async () => {
+    const card = await mount<HomematicScheduleCard>(CARD);
+    card.setConfig({ entity: "climate.missing" } as never);
+    await update(card, { hass: createHass({ language: "de", states: {} }) as never });
+
+    expect(textOf(card)).toContain("nicht gefunden");
+  });
+
+  it("lets the card config override the Home Assistant language", async () => {
+    const card = await mount<HomematicScheduleCard>(CARD);
+    card.setConfig({ entity: "climate.missing", language: "de" } as never);
+    await update(card, { hass: createHass({ language: "en", states: {} }) as never });
+
+    expect(textOf(card)).toContain("nicht gefunden");
+  });
+
+  describe("setConfig", () => {
+    it("accepts the single-entity form", async () => {
+      const card = await mountCard({ entity: "climate.living" });
+
+      expect(textOf(card)).toContain("Living Room");
+    });
+
+    it("accepts the list form with plain entity ids", async () => {
+      const card = await mountCard({ entities: ["climate.living"] });
+
+      expect(textOf(card)).toContain("Living Room");
+    });
+
+    it("accepts the list form with entity objects", async () => {
+      const card = await mountCard({ entities: [{ entity: "climate.living" }] });
+
+      expect(textOf(card)).toContain("Living Room");
+    });
+
+    it("trims surrounding whitespace", async () => {
+      const card = await mountCard({ entity: "  climate.living  " });
+
+      expect(textOf(card)).toContain("Living Room");
+    });
+
+    it("shows an entity selector once more than one entity is configured", async () => {
+      const card = await mountCard(
+        { entities: ["climate.living", "climate.bedroom"] },
+        statesOf(
+          thermostat("climate.living"),
+          thermostat("climate.bedroom", { friendly_name: "Bedroom" }),
+        ),
+      );
+
+      expect(
+        optionsOf(queryOrThrow(card, "ha-select.entity-selector")).map((option) => option.value),
+      ).toEqual(["climate.bedroom", "climate.living"]);
+    });
+
+    it("keeps no entity selector for a single entity", async () => {
+      const card = await mountCard({ entity: "climate.living" });
+
+      expect(query(card, "ha-select.entity-selector")).toBeNull();
+    });
+
+    it("ignores an empty entity id", async () => {
+      const card = await mountCard({ entity: "", entities: ["climate.living"] });
+
+      expect(textOf(card)).toContain("Living Room");
+    });
+  });
+});

--- a/packages/climate-schedule-card/src/localization.test.ts
+++ b/packages/climate-schedule-card/src/localization.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { formatString, getTranslations } from "./localization";
+
+describe("getTranslations", () => {
+  it("returns the English catalogue", () => {
+    expect(getTranslations("en").ui.schedule).toBe("Schedule");
+  });
+
+  it("returns the German catalogue", () => {
+    expect(getTranslations("de").ui.schedule).toBe("Zeitplan");
+  });
+
+  it("normalizes a regional language tag to its base language", () => {
+    expect(getTranslations("de-DE").ui.schedule).toBe("Zeitplan");
+    expect(getTranslations("en-US").ui.schedule).toBe("Schedule");
+  });
+
+  it("normalizes the case Home Assistant may send", () => {
+    expect(getTranslations("DE-de").ui.schedule).toBe("Zeitplan");
+  });
+
+  it("falls back to English for a language it does not carry", () => {
+    expect(getTranslations("fr").ui.schedule).toBe("Schedule");
+  });
+
+  it("covers every weekday in both catalogues", () => {
+    for (const language of ["en", "de"]) {
+      const { weekdays } = getTranslations(language);
+      expect(Object.keys(weekdays.short)).toHaveLength(7);
+      expect(Object.keys(weekdays.long)).toHaveLength(7);
+      expect(Object.values(weekdays.long).every(Boolean)).toBe(true);
+    }
+  });
+});
+
+describe("formatString", () => {
+  it("substitutes a named placeholder", () => {
+    expect(formatString("Entity {entity} not found", { entity: "climate.living_room" })).toBe(
+      "Entity climate.living_room not found",
+    );
+  });
+
+  it("substitutes several placeholders", () => {
+    expect(formatString("{a} then {b}", { a: "first", b: "second" })).toBe("first then second");
+  });
+
+  it("leaves a placeholder without a value in place", () => {
+    expect(formatString("Entity {entity} not found", {})).toBe("Entity {entity} not found");
+  });
+
+  it("ignores values that the template does not reference", () => {
+    expect(formatString("no placeholders", { entity: "climate.x" })).toBe("no placeholders");
+  });
+});

--- a/packages/config-panel/src/components/breadcrumb.test.ts
+++ b/packages/config-panel/src/components/breadcrumb.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { click, eventSpy, mount, queryAll, queryOrThrow, textOf } from "@hmip/test-utils";
+
+import "./breadcrumb";
+import type { BreadcrumbItem, HmBreadcrumb } from "./breadcrumb";
+
+const trail: BreadcrumbItem[] = [
+  { label: "Devices", view: "devices" },
+  { label: "Living Room Switch", view: "device", detail: { device: "VCU0000001" } },
+  { label: "Channel 1" },
+];
+
+describe("hm-breadcrumb", () => {
+  it("renders nothing while there is no trail to go back through", async () => {
+    const element = await mount<HmBreadcrumb>("hm-breadcrumb", { items: [trail[0]] });
+
+    expect(queryAll(element, "nav")).toHaveLength(0);
+  });
+
+  it("links every ancestor and marks the last item as the current page", async () => {
+    const element = await mount<HmBreadcrumb>("hm-breadcrumb", { items: trail });
+
+    expect(queryAll(element, "a.link").map((link) => link.textContent?.trim())).toEqual([
+      "Devices",
+      "Living Room Switch",
+    ]);
+
+    const current = queryOrThrow(element, ".current");
+    expect(current.textContent?.trim()).toBe("Channel 1");
+    expect(current.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("separates the entries", async () => {
+    const element = await mount<HmBreadcrumb>("hm-breadcrumb", { items: trail });
+
+    expect(queryAll(element, ".separator")).toHaveLength(2);
+    expect(textOf(element)).toBe("Devices › Living Room Switch › Channel 1");
+  });
+
+  it("merges the item detail into the navigation event", async () => {
+    const element = await mount<HmBreadcrumb>("hm-breadcrumb", { items: trail });
+    const navigations = eventSpy<{ view: string; device?: string }>(element, "breadcrumb-navigate");
+
+    await click(queryAll(element, "a.link")[1], element);
+
+    expect(navigations).toHaveLength(1);
+    expect(navigations[0].detail).toEqual({ view: "device", device: "VCU0000001" });
+  });
+
+  it("stays put when the clicked item has no target view", async () => {
+    const element = await mount<HmBreadcrumb>("hm-breadcrumb", {
+      items: [{ label: "Devices" }, { label: "Channel 1" }],
+    });
+    const navigations = eventSpy(element, "breadcrumb-navigate");
+
+    await click(queryOrThrow(element, "a.link"), element);
+
+    expect(navigations).toHaveLength(0);
+  });
+});

--- a/packages/config-panel/src/localize.test.ts
+++ b/packages/config-panel/src/localize.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { createHass } from "@hmip/test-utils";
+
+import { localize } from "./localize";
+
+describe("localize", () => {
+  it("resolves a dotted key from the English catalogue", () => {
+    expect(localize(createHass(), "common.back")).toBe("Back");
+  });
+
+  it("resolves the same key in German", () => {
+    expect(localize(createHass({ language: "de" }), "common.back")).toBe("Zurück");
+  });
+
+  it("falls back to English for a language without a catalogue", () => {
+    expect(localize(createHass({ language: "fr" }), "common.back")).toBe("Back");
+  });
+
+  it("substitutes placeholders", () => {
+    expect(localize(createHass(), "device_links.subtitle", { device: "Living Room Switch" })).toBe(
+      "Direct links for Living Room Switch",
+    );
+  });
+
+  it("substitutes numbers", () => {
+    expect(localize(createHass(), "change_history.parameters_changed", { count: 3 })).toBe(
+      "3 parameter(s) changed",
+    );
+  });
+
+  it("leaves placeholders the caller did not supply untouched", () => {
+    expect(localize(createHass(), "device_links.subtitle", {})).toBe("Direct links for {device}");
+  });
+
+  it("accepts keys carrying the panel prefix the backend sends", () => {
+    expect(localize(createHass(), "panel.common.back")).toBe("Back");
+  });
+
+  it("returns the key itself when nothing matches, so the gap is visible in the UI", () => {
+    expect(localize(createHass(), "common.no_such_key")).toBe("common.no_such_key");
+  });
+
+  it("treats a missing language as English", () => {
+    const hass = createHass();
+    // The panel runs against Home Assistant versions that may omit the field.
+    (hass.config as { language?: string }).language = undefined;
+
+    expect(localize(hass, "common.back")).toBe("Back");
+  });
+});

--- a/packages/config-panel/src/safe-element.test.ts
+++ b/packages/config-panel/src/safe-element.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { safeCustomElement } from "./safe-element";
+
+describe("safeCustomElement", () => {
+  it("registers the element under the given tag", () => {
+    class First extends HTMLElement {}
+    safeCustomElement("hm-safe-register")(First);
+
+    expect(customElements.get("hm-safe-register")).toBe(First);
+  });
+
+  it("returns the class so it can be used as a decorator", () => {
+    class First extends HTMLElement {}
+
+    expect(safeCustomElement("hm-safe-returns")(First)).toBe(First);
+  });
+
+  it("keeps the first registration when the script is loaded twice", () => {
+    class First extends HTMLElement {}
+    class Second extends HTMLElement {}
+    safeCustomElement("hm-safe-duplicate")(First);
+
+    expect(() => safeCustomElement("hm-safe-duplicate")(Second)).not.toThrow();
+    expect(customElements.get("hm-safe-duplicate")).toBe(First);
+  });
+
+  it("produces a working element", async () => {
+    class Greeting extends HTMLElement {
+      connectedCallback(): void {
+        this.textContent = "hello";
+      }
+    }
+    safeCustomElement("hm-safe-working")(Greeting);
+
+    const element = document.createElement("hm-safe-working");
+    document.body.appendChild(element);
+
+    expect(element.textContent).toBe("hello");
+    element.remove();
+  });
+});

--- a/packages/config-panel/src/unsaved-guard.test.ts
+++ b/packages/config-panel/src/unsaved-guard.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { isNavigationClick } from "./unsaved-guard";
+
+/** Build an anchor in the document and the click event that targets it. */
+function anchorClick(
+  attributes: Record<string, string>,
+  eventInit: MouseEventInit = {},
+): { anchor: HTMLAnchorElement; event: MouseEvent } {
+  const anchor = document.createElement("a");
+  for (const [name, value] of Object.entries(attributes)) {
+    anchor.setAttribute(name, value);
+  }
+  document.body.appendChild(anchor);
+  // The modifier flags are read-only, so they have to go through the constructor.
+  const event = new MouseEvent("click", {
+    bubbles: true,
+    composed: true,
+    cancelable: true,
+    ...eventInit,
+  });
+  // `composedPath()` is only populated while the event is being dispatched.
+  let path: EventTarget[] = [];
+  anchor.addEventListener("click", (dispatched) => {
+    path = dispatched.composedPath();
+  });
+  anchor.dispatchEvent(event);
+  Object.defineProperty(event, "composedPath", { value: () => path });
+  return { anchor, event };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("isNavigationClick", () => {
+  it("returns the in-app path of a plain left click", () => {
+    const { event } = anchorClick({ href: "/config/homematic/devices" });
+
+    expect(isNavigationClick(event)).toBe("/config/homematic/devices");
+  });
+
+  it("cancels the click so Home Assistant's router skips it", () => {
+    const { event } = anchorClick({ href: "/config/homematic/devices" });
+
+    isNavigationClick(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("leaves the click alone when asked not to prevent it", () => {
+    const { event } = anchorClick({ href: "/config/homematic/devices" });
+
+    expect(isNavigationClick(event, false)).toBe("/config/homematic/devices");
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it.each([
+    ["a middle click", { button: 1 }],
+    ["a meta click", { metaKey: true }],
+    ["a ctrl click", { ctrlKey: true }],
+    ["a shift click", { shiftKey: true }],
+  ])("ignores %s, which opens a new context", (_label, init) => {
+    const { event } = anchorClick({ href: "/config/homematic" }, init);
+
+    expect(isNavigationClick(event)).toBeUndefined();
+  });
+
+  it("ignores an already handled click", () => {
+    const { event } = anchorClick({ href: "/config/homematic" });
+    event.preventDefault();
+
+    expect(isNavigationClick(event)).toBeUndefined();
+  });
+
+  it("ignores a click that hit no anchor", () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    const event = new MouseEvent("click", { bubbles: true, composed: true, cancelable: true });
+    let path: EventTarget[] = [];
+    button.addEventListener("click", (dispatched) => (path = dispatched.composedPath()));
+    button.dispatchEvent(event);
+    Object.defineProperty(event, "composedPath", { value: () => path });
+
+    expect(isNavigationClick(event)).toBeUndefined();
+  });
+
+  it.each([
+    ["a link opening a new tab", { href: "/config", target: "_blank" }],
+    ["a download link", { href: "/config/export.json", download: "" }],
+    ["an explicitly external link", { href: "/config", rel: "external" }],
+    ["a mail link", { href: "mailto:someone@example.org" }],
+    ["a link to another origin", { href: "https://example.org/config" }],
+  ])("ignores %s", (_label, attributes) => {
+    const { event } = anchorClick(attributes);
+
+    expect(isNavigationClick(event)).toBeUndefined();
+  });
+
+  it("ignores an anchor without an href", () => {
+    const { event } = anchorClick({});
+
+    expect(isNavigationClick(event)).toBeUndefined();
+  });
+});

--- a/packages/config-panel/src/views/device-list.test.ts
+++ b/packages/config-panel/src/views/device-list.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  click,
+  createHass,
+  deviceInfo,
+  deepQuery,
+  deepQueryAll,
+  eventSpy,
+  mount,
+  query,
+  queryAll,
+  setValue,
+  textOf,
+  update,
+  type FakeHass,
+} from "@hmip/test-utils";
+
+import "./device-list";
+import type { HmDeviceList } from "./device-list";
+
+const LIST_DEVICES = "homematicip_local/config/list_devices";
+
+const devices = [
+  deviceInfo({
+    address: "VCU0000001",
+    name: "Living Room Switch",
+    model: "HmIP-BSM",
+    interface_id: "ccu-HmIP-RF",
+  }),
+  deviceInfo({
+    address: "VCU0000002",
+    name: "Bedroom Thermostat",
+    model: "HmIP-eTRV-2",
+    interface_id: "ccu-HmIP-RF",
+  }),
+  deviceInfo({
+    address: "MEQ0000003",
+    name: "Hallway Dimmer",
+    model: "HM-LC-Dim1T-FM",
+    interface_id: "ccu-BidCos-RF",
+  }),
+];
+
+/** Mount the list already wired to a `hass` that answers with `devices`. */
+async function mountList(
+  responses: Record<string, unknown> = { [LIST_DEVICES]: { devices } },
+): Promise<{ list: HmDeviceList; hass: FakeHass }> {
+  const hass = createHass({ ws: responses });
+  const list = await mount<HmDeviceList>("hm-device-list", { hass, entryId: "entry-1" });
+  return { list, hass };
+}
+
+/** The device names currently rendered, in render order. */
+const renderedNames = (list: HmDeviceList): string[] =>
+  deepQueryAll(list, ".device-name").map((element) => element.textContent?.trim() ?? "");
+
+describe("hm-device-list", () => {
+  it("loads the devices of the config entry once an entry is set", async () => {
+    const { hass } = await mountList();
+
+    expect(hass.lastSent(LIST_DEVICES)).toEqual({ type: LIST_DEVICES, entry_id: "entry-1" });
+  });
+
+  it("loads nothing while no entry is selected", async () => {
+    const hass = createHass({ ws: { [LIST_DEVICES]: { devices } } });
+    const list = await mount<HmDeviceList>("hm-device-list", { hass });
+
+    expect(hass.sentOf(LIST_DEVICES)).toHaveLength(0);
+    expect(textOf(list)).toContain("Please select a CCU to view devices.");
+  });
+
+  it("groups the devices by interface, dropping the instance prefix", async () => {
+    const { list } = await mountList();
+
+    expect(deepQueryAll(list, "hm-interface-header").map((header) => textOf(header))).toEqual([
+      "HmIP-RF",
+      "BidCos-RF",
+    ]);
+  });
+
+  it("renders one row per device", async () => {
+    const { list } = await mountList();
+
+    expect(renderedNames(list)).toHaveLength(3);
+  });
+
+  it("sorts by name ascending by default", async () => {
+    const { list } = await mountList();
+
+    expect(renderedNames(list)).toEqual([
+      "Bedroom Thermostat",
+      "Living Room Switch",
+      "Hallway Dimmer",
+    ]);
+  });
+
+  it("reverses the order when the active sort column is clicked again", async () => {
+    const { list } = await mountList();
+    const sortByName = queryAll(list, ".sort-button")[0];
+
+    await click(sortByName, list);
+
+    expect(renderedNames(list)).toEqual([
+      "Living Room Switch",
+      "Bedroom Thermostat",
+      "Hallway Dimmer",
+    ]);
+  });
+
+  it("switches to another column ascending", async () => {
+    const { list } = await mountList();
+    const sortByAddress = queryAll(list, ".sort-button")[1];
+
+    await click(sortByAddress, list);
+
+    // MEQ0000003 sorts first, so its interface group is emitted first.
+    expect(renderedNames(list)).toEqual([
+      "Hallway Dimmer",
+      "Living Room Switch",
+      "Bedroom Thermostat",
+    ]);
+  });
+
+  describe("search", () => {
+    let list: HmDeviceList;
+
+    beforeEach(async () => {
+      ({ list } = await mountList());
+    });
+
+    it("matches the device name case-insensitively", async () => {
+      setValue(query(list, "ha-input")!, "bedroom");
+      await update(list, {});
+
+      expect(renderedNames(list)).toEqual(["Bedroom Thermostat"]);
+    });
+
+    it("matches the address", async () => {
+      setValue(query(list, "ha-input")!, "MEQ");
+      await update(list, {});
+
+      expect(renderedNames(list)).toEqual(["Hallway Dimmer"]);
+    });
+
+    it("matches the model", async () => {
+      setValue(query(list, "ha-input")!, "eTRV");
+      await update(list, {});
+
+      expect(renderedNames(list)).toEqual(["Bedroom Thermostat"]);
+    });
+
+    it("shows the empty state when nothing matches", async () => {
+      setValue(query(list, "ha-input")!, "no-such-device");
+      await update(list, {});
+
+      expect(renderedNames(list)).toEqual([]);
+      expect(textOf(list)).toContain("No configurable devices found.");
+    });
+  });
+
+  it("bubbles the device selection out of the row", async () => {
+    const { list } = await mountList();
+    const selections = eventSpy<{ device: string; interfaceId: string }>(list, "device-selected");
+
+    await click(deepQuery(list, ".device-card")!, list);
+
+    expect(selections).toHaveLength(1);
+    expect(selections[0].detail).toEqual({
+      device: "VCU0000002",
+      interfaceId: "ccu-HmIP-RF",
+    });
+  });
+
+  it("shows the empty state when the entry has no devices", async () => {
+    const { list } = await mountList({ [LIST_DEVICES]: { devices: [] } });
+
+    expect(textOf(list)).toContain("No configurable devices found.");
+  });
+
+  describe("when the backend fails", () => {
+    it("surfaces the error message", async () => {
+      const hass = createHass();
+      hass.failWith(LIST_DEVICES, new Error("central not connected"));
+      const list = await mount<HmDeviceList>("hm-device-list", { hass, entryId: "entry-1" });
+
+      expect(textOf(list)).toContain("central not connected");
+    });
+
+    it("offers a retry that queries again", async () => {
+      const hass = createHass();
+      hass.failWith(LIST_DEVICES, new Error("central not connected"));
+      const list = await mount<HmDeviceList>("hm-device-list", { hass, entryId: "entry-1" });
+
+      hass.respond(LIST_DEVICES, { devices });
+      await click(query(list, "ha-button")!, list);
+
+      expect(hass.sentOf(LIST_DEVICES)).toHaveLength(2);
+      expect(renderedNames(list)).toHaveLength(3);
+    });
+  });
+});

--- a/packages/config-panel/tsconfig.check.json
+++ b/packages/config-panel/tsconfig.check.json
@@ -14,5 +14,5 @@
     }
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/packages/config-panel/tsconfig.json
+++ b/packages/config-panel/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "bundler"
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
   "references": [
     { "path": "../panel-api" },
     { "path": "../schedule-core" },

--- a/packages/panel-api/src/config-api.test.ts
+++ b/packages/panel-api/src/config-api.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import { createHass, deviceInfo, formSchema, userPermissions } from "@hmip/test-utils";
+
+import {
+  getDeviceIconUrl,
+  getFormSchema,
+  getParamset,
+  getUserPermissions,
+  listDevices,
+  putParamset,
+} from "./config-api";
+
+describe("getDeviceIconUrl", () => {
+  it("points at the integration's icon endpoint of the entry", () => {
+    expect(getDeviceIconUrl("entry-1", "hmip-bsm.png")).toBe(
+      "/api/homematicip_local/entry-1/device_icon/hmip-bsm.png",
+    );
+  });
+});
+
+describe("listDevices", () => {
+  it("sends the entry id and unwraps the device list", async () => {
+    const device = deviceInfo();
+    const hass = createHass({
+      ws: { "homematicip_local/config/list_devices": { devices: [device] } },
+    });
+
+    expect(await listDevices(hass, "entry-1")).toEqual([device]);
+    expect(hass.lastSent("homematicip_local/config/list_devices")).toEqual({
+      type: "homematicip_local/config/list_devices",
+      entry_id: "entry-1",
+    });
+  });
+
+  it("propagates a backend failure instead of swallowing it", async () => {
+    const hass = createHass();
+    hass.failWith("homematicip_local/config/list_devices", new Error("central not connected"));
+
+    await expect(listDevices(hass, "entry-1")).rejects.toThrow("central not connected");
+  });
+});
+
+describe("getFormSchema", () => {
+  it("defaults to the MASTER paramset and an unset channel type", async () => {
+    const hass = createHass({
+      ws: { "homematicip_local/config/get_form_schema": formSchema() },
+    });
+
+    await getFormSchema(hass, "entry-1", "ccu-HmIP-RF", "VCU0000001:1");
+
+    expect(hass.lastSent("homematicip_local/config/get_form_schema")).toMatchObject({
+      entry_id: "entry-1",
+      interface_id: "ccu-HmIP-RF",
+      channel_address: "VCU0000001:1",
+      channel_type: "",
+      paramset_key: "MASTER",
+    });
+  });
+
+  it("passes an explicit paramset key through", async () => {
+    const hass = createHass({
+      ws: { "homematicip_local/config/get_form_schema": formSchema() },
+    });
+
+    await getFormSchema(hass, "entry-1", "ccu-HmIP-RF", "VCU0000001:1", "SWITCH", "VALUES");
+
+    expect(hass.lastSent("homematicip_local/config/get_form_schema")).toMatchObject({
+      channel_type: "SWITCH",
+      paramset_key: "VALUES",
+    });
+  });
+});
+
+describe("getParamset", () => {
+  it("unwraps the values object", async () => {
+    const hass = createHass({
+      ws: { "homematicip_local/config/get_paramset": { values: { GLOBAL_BUTTON_LOCK: true } } },
+    });
+
+    expect(await getParamset(hass, "entry-1", "ccu-HmIP-RF", "VCU0000001:1")).toEqual({
+      GLOBAL_BUTTON_LOCK: true,
+    });
+  });
+});
+
+describe("putParamset", () => {
+  it("validates by default", async () => {
+    const hass = createHass({
+      ws: {
+        "homematicip_local/config/put_paramset": {
+          success: true,
+          validated: true,
+          validation_errors: {},
+        },
+      },
+    });
+
+    const result = await putParamset(hass, "entry-1", "ccu-HmIP-RF", "VCU0000001:1", {
+      GLOBAL_BUTTON_LOCK: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(hass.lastSent("homematicip_local/config/put_paramset")).toMatchObject({
+      paramset_key: "MASTER",
+      validate: true,
+      values: { GLOBAL_BUTTON_LOCK: true },
+    });
+  });
+
+  it("can write without validating", async () => {
+    const hass = createHass({
+      ws: {
+        "homematicip_local/config/put_paramset": {
+          success: true,
+          validated: false,
+          validation_errors: {},
+        },
+      },
+    });
+
+    await putParamset(hass, "entry-1", "ccu-HmIP-RF", "VCU0000001:1", {}, "VALUES", false);
+
+    expect(hass.lastSent("homematicip_local/config/put_paramset")).toMatchObject({
+      paramset_key: "VALUES",
+      validate: false,
+    });
+  });
+});
+
+describe("getUserPermissions", () => {
+  it("returns the backend the entry runs on", async () => {
+    const hass = createHass({
+      ws: {
+        "homematicip_local/config/get_user_permissions": userPermissions({
+          backend: "openccu-loom",
+          is_admin: false,
+        }),
+      },
+    });
+
+    const permissions = await getUserPermissions(hass, "entry-1");
+
+    expect(permissions.backend).toBe("openccu-loom");
+    expect(permissions.is_admin).toBe(false);
+  });
+});

--- a/packages/panel-api/src/radio-levels.test.ts
+++ b/packages/panel-api/src/radio-levels.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import { createHass, hassEntity } from "@hmip/test-utils";
+
+import { csLevelClass, dcLevelClass, getRadioLevels, loadEntryEntityIds } from "./radio-levels";
+
+const dutyCycle = (id: string, name: string, state: string) =>
+  hassEntity(`sensor.${id}_duty_cycle_level`, state, { friendly_name: `${name} Duty Cycle Level` });
+
+const carrierSense = (id: string, name: string, state: string) =>
+  hassEntity(`sensor.${id}_carrier_sense_level`, state, {
+    friendly_name: `${name} Carrier Sense Level`,
+  });
+
+const statesOf = (...entities: ReturnType<typeof hassEntity>[]) =>
+  Object.fromEntries(entities.map((entity) => [entity.entity_id, entity]));
+
+describe("getRadioLevels", () => {
+  it("returns nothing without states", () => {
+    expect(getRadioLevels(undefined, undefined)).toEqual([]);
+  });
+
+  it("pairs the duty cycle and carrier sense sensors of one device", () => {
+    const levels = getRadioLevels(
+      statesOf(dutyCycle("ccu", "CCU", "12.5"), carrierSense("ccu", "CCU", "3")),
+      undefined,
+    );
+
+    expect(levels).toEqual([{ name: "CCU", dutyCycle: 12.5, carrierSense: 3 }]);
+  });
+
+  it("leaves the missing half of a pair null", () => {
+    const levels = getRadioLevels(statesOf(dutyCycle("ccu", "CCU", "12.5")), undefined);
+
+    expect(levels).toEqual([{ name: "CCU", dutyCycle: 12.5, carrierSense: null }]);
+  });
+
+  it("ignores sensors that are neither duty cycle nor carrier sense", () => {
+    const levels = getRadioLevels(
+      statesOf(hassEntity("sensor.ccu_temperature", "21.5"), dutyCycle("ccu", "CCU", "1")),
+      undefined,
+    );
+
+    expect(levels).toHaveLength(1);
+    expect(levels[0].name).toBe("CCU");
+  });
+
+  it("ignores non-sensor entities", () => {
+    expect(
+      getRadioLevels(statesOf(hassEntity("switch.ccu_duty_cycle_level", "5")), undefined),
+    ).toEqual([]);
+  });
+
+  it("keeps a non-numeric state as null instead of NaN", () => {
+    const levels = getRadioLevels(statesOf(dutyCycle("ccu", "CCU", "unavailable")), undefined);
+
+    expect(levels).toEqual([{ name: "CCU", dutyCycle: null, carrierSense: null }]);
+  });
+
+  it("falls back to the entity id when the entity has no friendly name", () => {
+    const levels = getRadioLevels(
+      { "sensor.ccu_duty_cycle_level": hassEntity("sensor.ccu_duty_cycle_level", "1") },
+      undefined,
+    );
+
+    expect(levels[0].name).toBe("sensor.ccu_duty_cycle_level");
+  });
+
+  it("strips the spaced and unspaced label suffixes", () => {
+    const levels = getRadioLevels(
+      {
+        "sensor.a_duty_cycle_level": hassEntity("sensor.a_duty_cycle_level", "1", {
+          friendly_name: "Hub A DutyCycle Level",
+        }),
+        "sensor.b_carrier_sense_level": hassEntity("sensor.b_carrier_sense_level", "1", {
+          friendly_name: "Hub B CarrierSense Level",
+        }),
+      },
+      undefined,
+    );
+
+    expect(levels.map((level) => level.name)).toEqual(["Hub A", "Hub B"]);
+  });
+
+  it("keeps only entities belonging to the config entry", () => {
+    const levels = getRadioLevels(
+      statesOf(dutyCycle("mine", "Mine", "1"), dutyCycle("other", "Other", "2")),
+      new Set(["sensor.mine_duty_cycle_level"]),
+    );
+
+    expect(levels.map((level) => level.name)).toEqual(["Mine"]);
+  });
+
+  it("sorts devices by name", () => {
+    const levels = getRadioLevels(
+      statesOf(
+        dutyCycle("zulu", "Zulu", "1"),
+        dutyCycle("alpha", "Alpha", "2"),
+        dutyCycle("mike", "Mike", "3"),
+      ),
+      undefined,
+    );
+
+    expect(levels.map((level) => level.name)).toEqual(["Alpha", "Mike", "Zulu"]);
+  });
+});
+
+describe("loadEntryEntityIds", () => {
+  it("keeps the entity ids of the requested entry only", async () => {
+    const hass = createHass({
+      ws: {
+        "config/entity_registry/list": [
+          { entity_id: "sensor.mine", config_entry_id: "entry-1" },
+          { entity_id: "sensor.other", config_entry_id: "entry-2" },
+        ],
+      },
+    });
+
+    expect(await loadEntryEntityIds(hass, "entry-1")).toEqual(new Set(["sensor.mine"]));
+  });
+
+  it("returns undefined when the registry is unreachable, so callers stop filtering", async () => {
+    const hass = createHass();
+    hass.failWith("config/entity_registry/list", new Error("unauthorized"));
+
+    expect(await loadEntryEntityIds(hass, "entry-1")).toBeUndefined();
+  });
+});
+
+describe("level severity classes", () => {
+  it.each([
+    [null, ""],
+    [0, ""],
+    [59.9, ""],
+    [60, "warning"],
+    [79.9, "warning"],
+    [80, "error"],
+    [100, "error"],
+  ])("maps a duty cycle of %s to %s", (value, expected) => {
+    expect(dcLevelClass(value)).toBe(expected);
+  });
+
+  it.each([
+    [null, ""],
+    [0, ""],
+    [9.9, ""],
+    [10, "error"],
+  ])("maps a carrier sense of %s to %s", (value, expected) => {
+    expect(csLevelClass(value)).toBe(expected);
+  });
+});

--- a/packages/schedule-card/src/card.test.ts
+++ b/packages/schedule-card/src/card.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import { createHass, hassEntity, mount, query, statesOf, textOf, update } from "@hmip/test-utils";
+
+import { HomematicScheduleCard } from "./card";
+
+const CARD = "homematicip-local-schedule-card";
+
+/** One "switch on at 06:30 on weekdays" event, in the backend's wire shape. */
+const scheduleEntries = {
+  "1": {
+    weekdays: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"],
+    time: "06:30",
+    condition: "fixed_time",
+    astro_type: null,
+    astro_offset_minutes: 0,
+    target_channels: ["VCU0000001:4"],
+    level: 1,
+    level_2: null,
+    duration: null,
+    ramp_time: null,
+    lock_mode: null,
+    lock_action: null,
+    permission: null,
+  },
+};
+
+/** A switch entity carrying the schedule attributes the card requires. */
+const scheduleEntity = (entityId: string, attributes: Record<string, unknown> = {}) =>
+  hassEntity(entityId, "on", {
+    friendly_name: "Garden Pump",
+    schedule_type: "default",
+    schedule_domain: "switch",
+    schedule_channel_address: "VCU0000001:4",
+    schedule_data: { entries: scheduleEntries },
+    ...attributes,
+  });
+
+async function mountCard(
+  config: Record<string, unknown>,
+  states: Record<string, ReturnType<typeof hassEntity>> = statesOf(
+    scheduleEntity("switch.garden_pump"),
+  ),
+): Promise<HomematicScheduleCard> {
+  const card = await mount<HomematicScheduleCard>(CARD);
+  card.setConfig(config as never);
+  await update(card, { hass: createHass({ states }) as never });
+  return card;
+}
+
+describe("schedule card", () => {
+  it("registers itself under the Lovelace card type", () => {
+    expect(customElements.get(CARD)).toBeDefined();
+  });
+
+  it("announces itself to the card picker", () => {
+    expect(window.customCards?.some((card) => card.type === CARD)).toBe(true);
+  });
+
+  it("offers an editable stub config to the card picker", () => {
+    expect(HomematicScheduleCard.getStubConfig()).toEqual({
+      entity: "",
+      editable: true,
+      hour_format: "24",
+    });
+  });
+
+  it("points the visual editor at its own editor element", () => {
+    expect(HomematicScheduleCard.getConfigElement().localName).toBe(`${CARD}-editor`);
+  });
+
+  it("renders nothing before Lovelace supplies a config", async () => {
+    const card = await mount<HomematicScheduleCard>(CARD);
+
+    expect(textOf(card)).toBe("");
+  });
+
+  it("renders the schedule list for a compatible entity", async () => {
+    const card = await mountCard({ entity: "switch.garden_pump" });
+
+    expect(query(card, "hmip-device-schedule-list")).not.toBeNull();
+  });
+
+  it("waits with a loading state until the entity carries schedule entries", async () => {
+    const card = await mountCard(
+      { entity: "switch.garden_pump" },
+      statesOf(scheduleEntity("switch.garden_pump", { schedule_data: undefined })),
+    );
+
+    expect(query(card, "hmip-device-schedule-list")).toBeNull();
+    expect(textOf(card)).toContain("Loading");
+  });
+
+  it("names the card after the entity", async () => {
+    const card = await mountCard({ entity: "switch.garden_pump" });
+
+    expect(textOf(card)).toContain("Garden Pump");
+  });
+
+  it("prefers an explicitly configured name", async () => {
+    const card = await mountCard({ entity: "switch.garden_pump", name: "Irrigation" });
+
+    expect(textOf(card)).toContain("Irrigation");
+  });
+
+  it("reports an entity that is not in the state machine", async () => {
+    const card = await mountCard({ entity: "switch.missing" }, {});
+
+    expect(textOf(card)).toContain("Entity switch.missing not found");
+  });
+
+  it("rejects an entity whose schedule type is not 'default'", async () => {
+    const card = await mountCard(
+      { entity: "climate.living" },
+      statesOf(scheduleEntity("climate.living", { schedule_type: "climate" })),
+    );
+
+    expect(textOf(card)).toContain("not a compatible schedule entity");
+  });
+
+  it("translates into the Home Assistant language", async () => {
+    const card = await mount<HomematicScheduleCard>(CARD);
+    card.setConfig({ entity: "switch.missing" } as never);
+    await update(card, { hass: createHass({ language: "de", states: {} }) as never });
+
+    expect(textOf(card)).toContain("nicht gefunden");
+  });
+
+  describe("setConfig", () => {
+    it("accepts the single-entity form", async () => {
+      const card = await mountCard({ entity: "switch.garden_pump" });
+
+      expect(textOf(card)).toContain("Garden Pump");
+    });
+
+    it("accepts the list form with plain entity ids", async () => {
+      const card = await mountCard({ entities: ["switch.garden_pump"] });
+
+      expect(textOf(card)).toContain("Garden Pump");
+    });
+
+    it("trims surrounding whitespace", async () => {
+      const card = await mountCard({ entity: "  switch.garden_pump  " });
+
+      expect(textOf(card)).toContain("Garden Pump");
+    });
+  });
+});

--- a/packages/schedule-ui/src/schedule-grid.test.ts
+++ b/packages/schedule-ui/src/schedule-grid.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import { click, eventSpy, mount, queryAll, update } from "@hmip/test-utils";
+import { WEEKDAYS, type SimpleProfileData, type Weekday } from "@hmip/schedule-core";
+
+import "./schedule-grid";
+import type { HmipScheduleGrid } from "./schedule-grid";
+import type { GridTranslations } from "./types";
+
+const weekdayShortLabels = Object.fromEntries(
+  WEEKDAYS.map((weekday) => [weekday, weekday.slice(0, 2)]),
+) as Record<Weekday, string>;
+
+const translations: GridTranslations = {
+  weekdayShortLabels,
+  clickToEdit: "Click to edit",
+  copySchedule: "Copy day",
+  pasteSchedule: "Paste day",
+};
+
+/** One warm morning period; the rest of the day stays at the base temperature. */
+const scheduleData: SimpleProfileData = Object.fromEntries(
+  WEEKDAYS.map((weekday) => [
+    weekday,
+    {
+      base_temperature: 17,
+      periods: [{ starttime: "06:00", endtime: "09:00", temperature: 21.5 }],
+    },
+  ]),
+);
+
+const mountGrid = (properties: Partial<HmipScheduleGrid> = {}) =>
+  mount<HmipScheduleGrid>("hmip-schedule-grid", { translations, scheduleData, ...properties });
+
+describe("hmip-schedule-grid", () => {
+  it("renders nothing before schedule data arrives", async () => {
+    const grid = await mount<HmipScheduleGrid>("hmip-schedule-grid", { translations });
+
+    expect(queryAll(grid, ".schedule-container")).toHaveLength(0);
+  });
+
+  it("renders a column per weekday", async () => {
+    const grid = await mountGrid();
+
+    expect(queryAll(grid, ".weekday-header")).toHaveLength(7);
+    expect(queryAll(grid, ".time-blocks")).toHaveLength(7);
+  });
+
+  it("labels the columns from the translations", async () => {
+    const grid = await mountGrid();
+
+    expect(queryAll(grid, ".weekday-label").map((label) => label.textContent?.trim())).toEqual([
+      "MO",
+      "TU",
+      "WE",
+      "TH",
+      "FR",
+      "SA",
+      "SU",
+    ]);
+  });
+
+  it("falls back to a shortened weekday when no translation is supplied", async () => {
+    const grid = await mount<HmipScheduleGrid>("hmip-schedule-grid", { scheduleData });
+
+    expect(queryAll(grid, ".weekday-label")[0].textContent?.trim()).toBe("MO");
+  });
+
+  it("fills the gaps around a period with base-temperature blocks", async () => {
+    const grid = await mountGrid();
+    const monday = queryAll(grid, ".time-blocks")[0];
+
+    // 00:00-06:00 base, 06:00-09:00 period, 09:00-24:00 base.
+    expect(queryAll(monday, ".time-block")).toHaveLength(3);
+  });
+
+  it("offers no copy and paste while it is read-only", async () => {
+    const grid = await mountGrid();
+
+    expect(queryAll(grid, ".copy-btn")).toHaveLength(0);
+    expect(queryAll(grid, ".paste-btn")).toHaveLength(0);
+  });
+
+  it("offers copy and paste per weekday once editable", async () => {
+    const grid = await mountGrid({ editable: true });
+
+    expect(queryAll(grid, ".copy-btn")).toHaveLength(7);
+    expect(queryAll(grid, ".paste-btn")).toHaveLength(7);
+  });
+
+  it("stays silent on a click while it is read-only", async () => {
+    const grid = await mountGrid();
+    const clicks = eventSpy(grid, "weekday-click");
+
+    await click(queryAll(grid, ".time-blocks")[0], grid);
+
+    expect(clicks).toHaveLength(0);
+  });
+
+  it("reports which weekday was clicked", async () => {
+    const grid = await mountGrid({ editable: true });
+    const clicks = eventSpy<{ weekday: Weekday }>(grid, "weekday-click");
+
+    await click(queryAll(grid, ".time-blocks")[2], grid);
+
+    expect(clicks.map((event) => event.detail.weekday)).toEqual(["WEDNESDAY"]);
+  });
+
+  it("reports a copy without also reporting the weekday click underneath", async () => {
+    const grid = await mountGrid({ editable: true });
+    const copies = eventSpy<{ weekday: Weekday }>(grid, "copy-schedule");
+    const clicks = eventSpy(grid, "weekday-click");
+
+    await click(queryAll(grid, ".copy-btn")[1], grid);
+
+    expect(copies.map((event) => event.detail.weekday)).toEqual(["TUESDAY"]);
+    expect(clicks).toHaveLength(0);
+  });
+
+  it("reports a paste for its weekday", async () => {
+    const grid = await mountGrid({ editable: true, copiedWeekday: "MONDAY" });
+    const pastes = eventSpy<{ weekday: Weekday }>(grid, "paste-schedule");
+
+    await click(queryAll(grid, ".paste-btn")[4], grid);
+
+    expect(pastes.map((event) => event.detail.weekday)).toEqual(["FRIDAY"]);
+  });
+
+  it("disables pasting until a weekday was copied", async () => {
+    const grid = await mountGrid({ editable: true });
+    const pasteButton = queryAll<HTMLElement & { disabled: boolean }>(grid, ".paste-btn")[0];
+
+    expect(pasteButton.disabled).toBe(true);
+
+    await update(grid, { copiedWeekday: "MONDAY" });
+
+    expect(queryAll<HTMLElement & { disabled: boolean }>(grid, ".paste-btn")[0].disabled).toBe(
+      false,
+    );
+  });
+
+  it("marks the weekday the schedule was copied from", async () => {
+    const grid = await mountGrid({ editable: true, copiedWeekday: "THURSDAY" });
+
+    expect(queryAll(grid, ".copy-btn.active")).toHaveLength(1);
+    expect(queryAll(grid, ".copy-btn")[3].classList.contains("active")).toBe(true);
+  });
+});

--- a/packages/schedule-ui/tsconfig.check.json
+++ b/packages/schedule-ui/tsconfig.check.json
@@ -9,5 +9,5 @@
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/packages/schedule-ui/tsconfig.json
+++ b/packages/schedule-ui/tsconfig.json
@@ -6,6 +6,6 @@
     "composite": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
   "references": [{ "path": "../schedule-core" }]
 }

--- a/packages/status-card/src/helpers.test.ts
+++ b/packages/status-card/src/helpers.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { createHass } from "@hmip/test-utils";
+
+import { fetchConfigEntryOptions } from "./helpers";
+
+const CONFIG_ENTRIES = "config_entries/get";
+
+describe("fetchConfigEntryOptions", () => {
+  it("asks only for the integration's own entries", async () => {
+    const hass = createHass({ ws: { [CONFIG_ENTRIES]: [] } });
+
+    await fetchConfigEntryOptions(hass);
+
+    expect(hass.lastSent(CONFIG_ENTRIES)).toEqual({
+      type: CONFIG_ENTRIES,
+      domain: "homematicip_local",
+    });
+  });
+
+  it("maps the entries to select options", async () => {
+    const hass = createHass({
+      ws: {
+        [CONFIG_ENTRIES]: [
+          { entry_id: "entry-1", title: "CCU Home", domain: "homematicip_local" },
+          { entry_id: "entry-2", title: "CCU Cabin", domain: "homematicip_local" },
+        ],
+      },
+    });
+
+    expect(await fetchConfigEntryOptions(hass)).toEqual([
+      { value: "entry-1", label: "CCU Home" },
+      { value: "entry-2", label: "CCU Cabin" },
+    ]);
+  });
+
+  it("returns an empty list when no entry is configured", async () => {
+    const hass = createHass({ ws: { [CONFIG_ENTRIES]: [] } });
+
+    expect(await fetchConfigEntryOptions(hass)).toEqual([]);
+  });
+
+  it("degrades to an empty list instead of breaking the card when the call fails", async () => {
+    const hass = createHass();
+    hass.failWith(CONFIG_ENTRIES, new Error("unauthorized"));
+
+    expect(await fetchConfigEntryOptions(hass)).toEqual([]);
+  });
+});

--- a/packages/status-card/tsconfig.check.json
+++ b/packages/status-card/tsconfig.check.json
@@ -19,5 +19,11 @@
     "../climate-schedule-card/src/**/*.ts",
     "../schedule-card/src/**/*.ts"
   ],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "../climate-schedule-card/src/**/*.test.ts",
+    "../schedule-card/src/**/*.test.ts"
+  ]
 }

--- a/packages/status-card/tsconfig.json
+++ b/packages/status-card/tsconfig.json
@@ -13,7 +13,13 @@
     "../climate-schedule-card/src/**/*.ts",
     "../schedule-card/src/**/*.ts"
   ],
-  "exclude": ["node_modules", "dist"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "../climate-schedule-card/src/**/*.test.ts",
+    "../schedule-card/src/**/*.test.ts"
+  ],
   "references": [
     { "path": "../panel-api" },
     { "path": "../schedule-core" },

--- a/test-utils/dom.ts
+++ b/test-utils/dom.ts
@@ -1,0 +1,184 @@
+/**
+ * DOM helpers for Lit component tests.
+ *
+ * Everything mounted through this module is tracked and torn down by the global
+ * `afterEach` in `setup.ts`, so tests never leak elements into the next case.
+ */
+import { render, type TemplateResult } from "lit";
+
+/** Anything Lit-like: it settles its render through `updateComplete`. */
+interface UpdatingElement extends HTMLElement {
+  updateComplete: Promise<boolean>;
+}
+
+const mounted: HTMLElement[] = [];
+
+const hasUpdateComplete = (element: HTMLElement): element is UpdatingElement =>
+  "updateComplete" in element;
+
+/** Detach everything mounted since the last cleanup. */
+export function cleanupMounted(): void {
+  while (mounted.length > 0) {
+    mounted.pop()?.remove();
+  }
+}
+
+/**
+ * Wait until the element finished rendering, including updates that a first
+ * render scheduled on its children.
+ */
+export async function settle(element: HTMLElement): Promise<void> {
+  if (hasUpdateComplete(element)) {
+    await element.updateComplete;
+  }
+  // A parent's `updateComplete` does not cover children that started updating
+  // during that same render, so give the scheduler one more turn.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  if (hasUpdateComplete(element)) {
+    await element.updateComplete;
+  }
+}
+
+/**
+ * Create a registered custom element, apply properties, attach it and wait for
+ * the first render.
+ *
+ * Throws when the tag is unknown — that almost always means the test forgot the
+ * side-effect import that registers the component, and an unregistered element
+ * would otherwise render as a silently empty `HTMLElement`.
+ */
+export async function mount<T extends HTMLElement>(
+  tag: string,
+  properties: Partial<T> = {},
+): Promise<T> {
+  if (!customElements.get(tag)) {
+    throw new Error(
+      `<${tag}> is not registered. Import the module that defines it before mounting.`,
+    );
+  }
+  const element = document.createElement(tag) as T;
+  Object.assign(element, properties);
+  document.body.appendChild(element);
+  mounted.push(element);
+  await settle(element);
+  return element;
+}
+
+/**
+ * Apply properties to an already mounted element and wait for the re-render.
+ */
+export async function update<T extends HTMLElement>(
+  element: T,
+  properties: Partial<T>,
+): Promise<T> {
+  Object.assign(element, properties);
+  await settle(element);
+  return element;
+}
+
+/** Render a Lit template into a fresh container and return that container. */
+export async function renderTemplate(template: TemplateResult): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  mounted.push(container);
+  render(template, container);
+  await settle(container);
+  return container;
+}
+
+/** The shadow root if the element has one, otherwise the element itself. */
+const rootOf = (host: Element | DocumentFragment): ParentNode =>
+  "shadowRoot" in host && host.shadowRoot ? host.shadowRoot : host;
+
+/** Query inside the host's shadow root (or the host itself for light DOM). */
+export function query<E extends Element = Element>(
+  host: Element | DocumentFragment,
+  selector: string,
+): E | null {
+  return rootOf(host).querySelector<E>(selector);
+}
+
+/** Like `query`, but throws instead of returning null. */
+export function queryOrThrow<E extends Element = Element>(
+  host: Element | DocumentFragment,
+  selector: string,
+): E {
+  const found = query<E>(host, selector);
+  if (!found) {
+    throw new Error(`No element matching "${selector}" in <${(host as Element).localName}>.`);
+  }
+  return found;
+}
+
+/** Query all matches inside the host's shadow root (or the host itself). */
+export function queryAll<E extends Element = Element>(
+  host: Element | DocumentFragment,
+  selector: string,
+): E[] {
+  return Array.from(rootOf(host).querySelectorAll<E>(selector));
+}
+
+/** Query across every nested shadow root below the host, depth first. */
+export function deepQueryAll<E extends Element = Element>(
+  host: Element | DocumentFragment,
+  selector: string,
+): E[] {
+  const found: E[] = [];
+  const visit = (node: ParentNode): void => {
+    for (const element of Array.from(node.querySelectorAll("*"))) {
+      if (element.matches(selector)) {
+        found.push(element as E);
+      }
+      if (element.shadowRoot) {
+        visit(element.shadowRoot);
+      }
+    }
+  };
+  visit(rootOf(host));
+  return found;
+}
+
+/** First match across every nested shadow root below the host. */
+export function deepQuery<E extends Element = Element>(
+  host: Element | DocumentFragment,
+  selector: string,
+): E | null {
+  return deepQueryAll<E>(host, selector)[0] ?? null;
+}
+
+/**
+ * Collapsed visible text of the host's rendered output.
+ *
+ * jsdom has no `adoptedStyleSheets`, so Lit falls back to injecting a `<style>`
+ * element into the shadow root. Its CSS is part of `textContent` and has to be
+ * dropped, or every assertion carries the component's stylesheet.
+ */
+export function textOf(host: Element | DocumentFragment): string {
+  const clone = document.createElement("div");
+  for (const child of Array.from(rootOf(host).childNodes)) {
+    clone.appendChild(child.cloneNode(true));
+  }
+  for (const styling of Array.from(clone.querySelectorAll("style, script"))) {
+    styling.remove();
+  }
+  return (clone.textContent ?? "").replace(/\s+/g, " ").trim();
+}
+
+/** Click an element and wait for the resulting render to settle. */
+export async function click(element: Element, host?: HTMLElement): Promise<void> {
+  element.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+  await settle(host ?? (element as HTMLElement));
+}
+
+/**
+ * Record every event of `type` dispatched on `target`.
+ *
+ * The `schedule-ui` components and the panel views talk to their consumers
+ * through CustomEvents, so asserting on the payload is the main way to test
+ * them without a live Home Assistant.
+ */
+export function eventSpy<D = unknown>(target: EventTarget, type: string): CustomEvent<D>[] {
+  const events: CustomEvent<D>[] = [];
+  target.addEventListener(type, (event) => events.push(event as CustomEvent<D>));
+  return events;
+}

--- a/test-utils/fixtures.ts
+++ b/test-utils/fixtures.ts
@@ -1,0 +1,97 @@
+/**
+ * Typed builders for the payloads the backend sends over the WebSocket API.
+ *
+ * Each builder returns a complete, valid object and merges the overrides a test
+ * cares about, so a test states only what is relevant to it. Because the return
+ * types come from `@hmip/panel-api`, a backend contract change breaks the
+ * fixtures at compile time instead of producing silently wrong test data.
+ */
+import type {
+  ChannelInfo,
+  DeviceInfo,
+  FormParameter,
+  FormSchema,
+  FormSection,
+  MaintenanceData,
+  UserPermissions,
+} from "@hmip/panel-api";
+
+export function maintenance(overrides: Partial<MaintenanceData> = {}): MaintenanceData {
+  return {
+    unreach: false,
+    low_bat: false,
+    dutycycle: false,
+    config_pending: false,
+    ...overrides,
+  };
+}
+
+export function channelInfo(overrides: Partial<ChannelInfo> = {}): ChannelInfo {
+  return {
+    address: "VCU0000001:1",
+    channel_type: "SWITCH_VIRTUAL_RECEIVER",
+    channel_type_label: "Switch",
+    paramset_keys: ["MASTER", "VALUES"],
+    ...overrides,
+  };
+}
+
+export function deviceInfo(overrides: Partial<DeviceInfo> = {}): DeviceInfo {
+  return {
+    address: "VCU0000001",
+    interface: "HmIP-RF",
+    interface_id: "ccu-HmIP-RF",
+    model: "HmIP-BSM",
+    model_description: "Brand Switch and Meter Actuator",
+    name: "Living Room Switch",
+    firmware: "1.16.6",
+    channels: [channelInfo()],
+    maintenance: maintenance(),
+    ...overrides,
+  };
+}
+
+export function formParameter(overrides: Partial<FormParameter> = {}): FormParameter {
+  return {
+    id: "GLOBAL_BUTTON_LOCK",
+    label: "Global button lock",
+    type: "boolean",
+    widget: "switch",
+    current_value: false,
+    writable: true,
+    modified: false,
+    ...overrides,
+  };
+}
+
+export function formSection(overrides: Partial<FormSection> = {}): FormSection {
+  return {
+    id: "general",
+    title: "General",
+    parameters: [formParameter()],
+    ...overrides,
+  };
+}
+
+export function formSchema(overrides: Partial<FormSchema> = {}): FormSchema {
+  const sections = overrides.sections ?? [formSection()];
+  const parameters = sections.flatMap((section) => section.parameters);
+  return {
+    channel_address: "VCU0000001:1",
+    channel_type: "SWITCH_VIRTUAL_RECEIVER",
+    channel_type_label: "Switch",
+    total_parameters: parameters.length,
+    writable_parameters: parameters.filter((parameter) => parameter.writable).length,
+    ...overrides,
+    sections,
+  };
+}
+
+export function userPermissions(overrides: Partial<UserPermissions> = {}): UserPermissions {
+  return {
+    is_admin: true,
+    permissions: [],
+    backend: "CCU",
+    ...overrides,
+  };
+}

--- a/test-utils/ha-stubs.ts
+++ b/test-utils/ha-stubs.ts
@@ -1,0 +1,79 @@
+/**
+ * Stand-ins for the `ha-*` elements Home Assistant provides at runtime.
+ *
+ * These elements are never bundled — the cards and the panel expect the
+ * frontend to have defined them. Without stubs an `<ha-select>` is an inert
+ * `HTMLElement`, so nothing dispatches the events the components listen for.
+ *
+ * The stubs keep their children in the light DOM, which makes `textOf()`
+ * assertions read exactly like the rendered template.
+ */
+
+/** Every `ha-*` element used across the packages. */
+const HA_TAGS = [
+  "ha-alert",
+  "ha-button",
+  "ha-card",
+  "ha-checkbox",
+  "ha-circular-progress",
+  "ha-dialog",
+  "ha-form",
+  "ha-icon",
+  "ha-icon-button",
+  "ha-input",
+  "ha-list-virtualized",
+  "ha-markdown",
+  "ha-menu-button",
+  "ha-radio-group",
+  "ha-radio-option",
+  "ha-select",
+  "ha-slider",
+  "ha-switch",
+] as const;
+
+/** Option list shape of `ha-select` (HA 2026.3.0+). */
+export interface HaSelectOption {
+  value: string;
+  label: string;
+}
+
+class HaStub extends HTMLElement {}
+
+/**
+ * Define the stubs. Idempotent, so setup files and individual tests can both
+ * call it without tripping over a duplicate registration.
+ */
+export function registerHaStubs(): void {
+  for (const tag of HA_TAGS) {
+    if (!customElements.get(tag)) {
+      customElements.define(tag, class extends HaStub {});
+    }
+  }
+}
+
+/**
+ * Pick an option on an `ha-select`, the way the real element does: set `value`,
+ * then dispatch `selected` carrying the value in `detail`.
+ */
+export function selectOption(select: Element, value: string): void {
+  (select as HTMLElement & { value: string }).value = value;
+  select.dispatchEvent(new CustomEvent("selected", { detail: { value }, bubbles: true }));
+}
+
+/** The options currently bound to an `ha-select`. */
+export function optionsOf(select: Element): HaSelectOption[] {
+  return (select as HTMLElement & { options?: HaSelectOption[] }).options ?? [];
+}
+
+/** Toggle an `ha-switch` / `ha-checkbox` and dispatch the `change` it reads. */
+export function setChecked(toggle: Element, checked: boolean): void {
+  (toggle as HTMLElement & { checked: boolean }).checked = checked;
+  toggle.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+/** Type into an `ha-input` / `ha-slider` / plain `<input>` and notify listeners. */
+export function setValue(input: Element, value: string | number): void {
+  (input as HTMLElement & { value: string | number }).value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+}

--- a/test-utils/hass.ts
+++ b/test-utils/hass.ts
@@ -1,0 +1,134 @@
+/**
+ * A fake `HomeAssistant` object.
+ *
+ * Every panel and card API call goes through `hass.callWS()`, so injecting a
+ * fake `hass` is the whole seam needed to test them — no module mocking, no
+ * live WebSocket connection.
+ *
+ * `@hmip/panel-api` and `@hmip/schedule-core` each declare their own slice of
+ * Home Assistant: the panel reads `config.language`, the cards read `language` /
+ * `locale.language`, and only the cards require `states`. The fake is built on
+ * the wider `schedule-core` shape, which structurally satisfies the panel's too,
+ * so a single helper serves every package.
+ */
+import type { HassEntity, HassUser, HomeAssistant } from "@hmip/schedule-core";
+
+/** A WebSocket message as the panel sends it: a command `type` plus payload. */
+export type WsMessage = Record<string, unknown> & { type: string };
+
+/** A canned response, or a function computing one from the incoming message. */
+export type WsResponse = unknown | ((message: WsMessage) => unknown);
+
+export interface FakeHassOptions {
+  /** Drives every language lookup; `"en"` unless a test needs other strings. */
+  language?: string;
+  darkMode?: boolean;
+  states?: Record<string, HassEntity>;
+  user?: Partial<HassUser>;
+  /** Responses keyed by the command `type` the code under test sends. */
+  ws?: Record<string, WsResponse>;
+}
+
+export interface FakeHass extends HomeAssistant {
+  themes: { darkMode: boolean };
+  user: HassUser;
+  /** Every message passed to `callWS`, in call order. */
+  readonly sent: WsMessage[];
+  /** The messages sent for one command type. */
+  sentOf(type: string): WsMessage[];
+  /** The single message sent for one command type; throws unless there is exactly one. */
+  lastSent(type: string): WsMessage;
+  /** Register or replace a response after construction. */
+  respond(type: string, response: WsResponse): void;
+  /** Make a command reject, to exercise error paths. */
+  failWith(type: string, error: Error): void;
+}
+
+/** Marker for responses that should reject rather than resolve. */
+class Rejection {
+  constructor(readonly error: Error) {}
+}
+
+/**
+ * Build a fake `hass`.
+ *
+ * Commands without a registered response reject with a message naming the type,
+ * so a forgotten stub fails loudly instead of resolving to `undefined` and
+ * surfacing much later as an unrelated render error.
+ */
+export function createHass(options: FakeHassOptions = {}): FakeHass {
+  const responses = new Map<string, WsResponse>(Object.entries(options.ws ?? {}));
+  const sent: WsMessage[] = [];
+  const language = options.language ?? "en";
+
+  const hass: FakeHass = {
+    config: { language },
+    language,
+    locale: { language },
+    themes: { darkMode: options.darkMode ?? false },
+    states: options.states ?? {},
+    user: { id: "user-1", name: "Test User", is_owner: true, is_admin: true, ...options.user },
+    sent,
+
+    async callWS<T>(message: Record<string, unknown>): Promise<T> {
+      const typed = message as WsMessage;
+      sent.push(typed);
+
+      if (!responses.has(typed.type)) {
+        throw new Error(
+          `createHass: no response registered for "${typed.type}". ` +
+            `Registered: ${[...responses.keys()].join(", ") || "(none)"}`,
+        );
+      }
+
+      const response = responses.get(typed.type);
+      const resolved = typeof response === "function" ? response(typed) : response;
+      if (resolved instanceof Rejection) {
+        throw resolved.error;
+      }
+      return resolved as T;
+    },
+
+    sentOf(type: string): WsMessage[] {
+      return sent.filter((message) => message.type === type);
+    },
+
+    lastSent(type: string): WsMessage {
+      const matches = sent.filter((message) => message.type === type);
+      if (matches.length === 0) {
+        throw new Error(`createHass: "${type}" was never sent.`);
+      }
+      return matches[matches.length - 1];
+    },
+
+    respond(type: string, response: WsResponse): void {
+      responses.set(type, response);
+    },
+
+    failWith(type: string, error: Error): void {
+      responses.set(type, new Rejection(error));
+    },
+  };
+
+  return hass;
+}
+
+/** A `HassEntity`, for the cards that read `hass.states`. */
+export function hassEntity(
+  entityId: string,
+  state = "on",
+  attributes: Record<string, unknown> = {},
+): HassEntity {
+  return {
+    entity_id: entityId,
+    state,
+    attributes,
+    last_changed: "2026-01-01T00:00:00.000Z",
+    last_updated: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+/** Index entities by their id, ready for `createHass({ states })`. */
+export function statesOf(...entities: HassEntity[]): Record<string, HassEntity> {
+  return Object.fromEntries(entities.map((entity) => [entity.entity_id, entity]));
+}

--- a/test-utils/index.ts
+++ b/test-utils/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared test helpers for the Vitest suites.
+ *
+ * Import through the `@hmip/test-utils` alias, which `vitest.config.ts` maps to
+ * this file:
+ *
+ * ```ts
+ * import { createHass, mount, textOf } from "@hmip/test-utils";
+ * ```
+ */
+export * from "./dom";
+export * from "./fixtures";
+export * from "./ha-stubs";
+export * from "./hass";

--- a/test-utils/setup.ts
+++ b/test-utils/setup.ts
@@ -1,0 +1,66 @@
+/**
+ * Global test setup, loaded before every Vitest file.
+ *
+ * jsdom implements neither the observer APIs nor the Web Animations API, both of
+ * which Lit components and Home Assistant elements touch while rendering. Each
+ * polyfill is installed only when missing, so a future jsdom that ships the real
+ * thing wins over the stub.
+ */
+import { afterEach } from "vitest";
+
+import { cleanupMounted } from "./dom";
+import { registerHaStubs } from "./ha-stubs";
+
+class ObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): [] {
+    return [];
+  }
+}
+
+if (!("ResizeObserver" in globalThis)) {
+  globalThis.ResizeObserver = ObserverStub as unknown as typeof ResizeObserver;
+}
+
+if (!("IntersectionObserver" in globalThis)) {
+  globalThis.IntersectionObserver = ObserverStub as unknown as typeof IntersectionObserver;
+}
+
+if (!window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function scrollIntoView(): void {};
+}
+
+if (!Element.prototype.animate) {
+  Element.prototype.animate = function animate(): Animation {
+    return {
+      cancel: () => {},
+      finish: () => {},
+      play: () => {},
+      pause: () => {},
+      finished: Promise.resolve(),
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    } as unknown as Animation;
+  };
+}
+
+registerHaStubs();
+
+afterEach(() => {
+  cleanupMounted();
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,26 @@
+{
+  // Type-checks everything the package tsconfigs deliberately exclude: the test
+  // files and the shared helpers. Run through `npm run type-check:tests`.
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "types": ["vitest/globals"],
+    // Mirrors the aliases in vitest.config.ts. Relative to this file, since
+    // `baseUrl` is deprecated as of TypeScript 6.
+    "paths": {
+      "@hmip/panel-api": ["./packages/panel-api/src/index.ts"],
+      "@hmip/schedule-core": ["./packages/schedule-core/src/index.ts"],
+      "@hmip/schedule-ui": ["./packages/schedule-ui/src/index.ts"],
+      "@hmip/climate-schedule-card": ["./packages/climate-schedule-card/src/card.ts"],
+      "@hmip/schedule-card": ["./packages/schedule-card/src/card.ts"],
+      "@hmip/test-utils": ["./test-utils/index.ts"]
+    }
+  },
+  "include": ["test-utils/**/*.ts", "vitest.config.ts", "packages/*/src/**/*.test.ts"],
+  "exclude": ["node_modules", "**/dist/**", "packages/schedule-core/src/**/*.test.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,67 @@
+/**
+ * Vitest configuration for every package that imports Lit.
+ *
+ * `schedule-core` keeps its Jest suite: it is pure logic, imports no Lit, and
+ * ts-jest' CommonJS transform handles it. Lit 3 ships ESM only, which Jest can
+ * load solely through `--experimental-vm-modules`; Vitest is ESM-native, so the
+ * Lit packages run here instead.
+ *
+ * Workspace packages resolve to their *sources*, not to `dist/`, so tests always
+ * run against the current code and never require a build first.
+ */
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+const from = (relativePath: string): string =>
+  fileURLToPath(new URL(relativePath, import.meta.url));
+
+/** One Vitest project per package, sharing the root config via `extends`. */
+const project = (name: string) => ({
+  // `as const`: a widened `boolean` would not match Vitest's `string | true`.
+  extends: true as const,
+  test: {
+    name,
+    include: [`packages/${name}/src/**/*.test.ts`],
+  },
+});
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@hmip/panel-api": from("./packages/panel-api/src/index.ts"),
+      "@hmip/schedule-core": from("./packages/schedule-core/src/index.ts"),
+      "@hmip/schedule-ui": from("./packages/schedule-ui/src/index.ts"),
+      "@hmip/climate-schedule-card": from("./packages/climate-schedule-card/src/card.ts"),
+      "@hmip/schedule-card": from("./packages/schedule-card/src/card.ts"),
+      "@hmip/test-utils": from("./test-utils/index.ts"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: [from("./test-utils/setup.ts")],
+    restoreMocks: true,
+    projects: [
+      project("panel-api"),
+      project("schedule-ui"),
+      project("config-panel"),
+      project("climate-schedule-card"),
+      project("schedule-card"),
+      project("status-card"),
+    ],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      include: ["packages/*/src/**/*.ts"],
+      exclude: [
+        // schedule-core is measured by its own Jest coverage run.
+        "packages/schedule-core/**",
+        "**/*.d.ts",
+        "**/*.test.ts",
+        "**/index.ts",
+        "**/styles.ts",
+        "**/styles/**",
+      ],
+    },
+  },
+});


### PR DESCRIPTION
Six of the seven packages had no tests — roughly 11k lines in the config panel alone, and all of the user-facing behaviour. #89 had to note that its filter was "verified by build and type-check alone" for exactly this reason. They now have a harness and **142 tests**.

Closes the open Dependabot alert (#26) on the way.

## Why Vitest and not Jest

Lit 3 ships ESM only. Jest can load it solely behind `--experimental-vm-modules`, and mocking under that flag needs `jest.unstable_mockModule` plus dynamic imports in every single file. Vitest is ESM-native.

`schedule-core` **keeps its Jest suite**: it imports no Lit, its 213 tests pass unchanged, and rewriting them would buy nothing. `make test` runs both runners.

## The seam

The code already had the right one: every API call in every package goes through `hass.callWS()`. A fake `hass` therefore replaces the backend **without mocking a single module**.

```ts
const hass = createHass({
  ws: { "homematicip_local/config/list_devices": { devices: [deviceInfo()] } },
});
const list = await mount<HmDeviceList>("hm-device-list", { hass, entryId: "entry-1" });

expect(hass.lastSent("homematicip_local/config/list_devices")).toEqual({ ... });
```

A command with no registered response **rejects with a message naming it**, so a forgotten stub fails where it happens rather than as a confusing render error three steps later. `hass.respond()` swaps a response mid-test, `hass.failWith()` drives error paths.

The fake is built on the wider `@hmip/schedule-core` `HomeAssistant` shape, which structurally satisfies the `@hmip/panel-api` one — the panel reads `config.language`, the cards read `language`/`locale.language`, so one helper serves both.

## `test-utils/`

At the repo root rather than under `packages/`, so it stays out of `build`, `type-check --workspaces` and the release scripts. Aliased as `@hmip/test-utils`.

| Module | Provides |
| --- | --- |
| `hass.ts` | `createHass()`, `hassEntity()`, `statesOf()` |
| `dom.ts` | `mount()`, `update()`, `click()`, `query*()`, `deepQuery*()`, `textOf()`, `eventSpy()` |
| `ha-stubs.ts` | Stand-ins for all 17 `ha-*` elements in use, plus interaction helpers |
| `fixtures.ts` | Payload builders typed from `@hmip/panel-api` — a backend contract change breaks them at compile time instead of producing silently wrong test data |
| `setup.ts` | jsdom polyfills, stub registration, per-test DOM cleanup |

Two helpers that exist because of specific traps: `mount()` throws on an unregistered tag (otherwise a missing side-effect import renders a silently empty `HTMLElement`), and `textOf()` strips the `<style>` element Lit injects because jsdom has no `adoptedStyleSheets`.

## What is covered

| Package | Suites | Covers |
| --- | --- | --- |
| `panel-api` | `radio-levels`, `config-api` | Level pairing/filtering/severity, WS message shape, response unwrapping |
| `schedule-ui` | `schedule-grid` | Weekday columns, gap filling, copy/paste events, read-only mode |
| `config-panel` | `localize`, `unsaved-guard`, `safe-element`, `breadcrumb`, `views/device-list` | Translation fallbacks, navigation-click matrix, duplicate registration, grouping/sort/search/retry |
| `climate-schedule-card` | `localization`, `card` | Language normalization, `setConfig` forms, render error branches |
| `schedule-card` | `card` | Stub config, entity compatibility, loading state |
| `status-card` | `helpers` | Config-entry options, graceful failure |

## Build and type-check

Aliases resolve to **sources**, not `dist/` — tests need no build first and fail against the code as written.

Test files are excluded from every build tsconfig (verified: nothing lands in `dist/`) and type-checked by the new `tsconfig.test.json`, which `make type-check` now runs too. `status-card` lists the sibling test paths explicitly because `exclude` globs do not traverse `../`.

## Security

Both advisories were already in the tree before this branch, both reachable only through dev dependencies:

| Advisory | Package | Chain | Fix |
| --- | --- | --- | --- |
| GHSA-5p4m-2wfm-xmqj | `js-yaml` 3.15.0 | ts-jest → @jest/transform → babel-plugin-istanbul → @istanbuljs/load-nyc-config | → 3.15.1, lockfile only |
| GHSA-rgw5-rvv9-x895 | `brace-expansion` 5.0.8 | eslint → minimatch | → 5.0.9, needs an `overrides` entry |

js-yaml deliberately gets **no** `overrides` entry: it would pin a future js-yaml 4.x down to 3.x. brace-expansion needs one because npm 9 does not re-resolve it even though `minimatch` asks for `^5.0.5` and 5.0.9 is `latest`. `npm audit` reports 0 vulnerabilities.

## New targets

`make test-core`, `make test-vitest`, `make test-pkg PKG=<name>`, `make test-coverage` (Vitest) and `make test-coverage-core` (Jest). `make test-watch` now watches the Vitest suites; the old schedule-core watcher is `make test-watch-core`.

## Notes for review

- **`jsdom` is pinned to `^27.4.0`.** Version 30 requires Node >=22.22.2 and would break the 20.x leg of the CI matrix.
- **`registerHaStubs()` defines `ha-list-virtualized`**, which makes `hm-device-list` take its virtualized branch above 100 devices. The stub renders no rows, so list tests stay under that threshold — documented in CLAUDE.md.
- **Found while writing the tests, not fixed here:** the `href === "#"` check in `unsaved-guard.ts` is dead code. `anchor.href` is always absolute, so after `slice(origin.length)` the value is `/#`, never `#`. Because `UnsavedGuard` listens in the capture phase — before the anchor's own `preventDefault()` — a breadcrumb click (`<a href="#">`) while `channel-config` or `link-config` holds unsaved changes should raise a spurious discard prompt. Worth its own PR.
- `make format-check` is red on 27 files this branch does not touch; CI does not run it, and only the files changed here were formatted.
